### PR TITLE
v1.3: complete operator hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Reframed the main window around explicit readiness, fan-control ownership, and one safe next action.
 - Made manual fan edits draft-first with explicit Apply semantics and immediate Auto restoration.
 - Improved per-fan curve visibility, profile discoverability, fan target/drift rows, menu-bar status, native Settings categories, compact layouts, and accessibility output.
+- Centralized app polling ownership, made manual startup defaults draft-only, improved 1280-class pane allocation, and added native Open Vifty and safely gated Restore Auto commands.
+- Made copied support feedback temporary and completed source-level command, layout, startup-safety, and accessibility contracts for the release candidate.
 
 ## [1.2.0] - 2026-07-11
 

--- a/Sources/Vifty/AppModel.swift
+++ b/Sources/Vifty/AppModel.swift
@@ -897,6 +897,13 @@ final class AppModel: ObservableObject {
         Task { await performAutoRestore(generation: generation) }
     }
 
+    var canRequestRestoreAuto: Bool {
+        controlSessionPresentation.primaryAction == .restoreAuto
+            || controlState.manualControlActive
+            || controlState.mode != .auto
+            || agentControlStatus?.activeLease != nil
+    }
+
     func markFanControlDraftPending() {
         guard selectedMode != .auto else { return }
         if !hasPendingFanControlChanges,

--- a/Sources/Vifty/AppModel.swift
+++ b/Sources/Vifty/AppModel.swift
@@ -449,7 +449,6 @@ final class AppModel: ObservableObject {
         maxAttempts: Int = 1,
         retryDelay: Duration = .milliseconds(250)
     ) async {
-        start()
         let attempts = max(1, maxAttempts)
         for attempt in 1...attempts {
             guard menuBarLabelNeedsTelemetryPrime else { return }

--- a/Sources/Vifty/AppModel.swift
+++ b/Sources/Vifty/AppModel.swift
@@ -503,7 +503,7 @@ final class AppModel: ObservableObject {
             await pollOnce()
             selectedMode = startupMode
         }
-        await applyCurrentModeSelection()
+        markFanControlDraftPending()
     }
 
     func stop() {

--- a/Sources/Vifty/ContentView.swift
+++ b/Sources/Vifty/ContentView.swift
@@ -5,6 +5,7 @@ struct ContentView: View {
     @EnvironmentObject private var model: AppModel
     @StateObject private var daemonInstaller = DaemonInstaller()
     @State private var helperRefreshTask: Task<Void, Never>?
+    @State private var helperDiagnosticsFeedbackTask: Task<Void, Never>?
     @State private var helperDiagnosticsCopied = false
 
     var body: some View {
@@ -27,6 +28,10 @@ struct ContentView: View {
             mainContent
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .onDisappear {
+            helperDiagnosticsFeedbackTask?.cancel()
+            helperDiagnosticsFeedbackTask = nil
+        }
     }
 
     private var mainContent: some View {
@@ -307,6 +312,13 @@ struct ContentView: View {
     private func copyHelperDiagnosticsCommand() {
         HelperDiagnosticsSupport.copySupportEvidenceCommand(context: model.helperSupportEvidenceContext)
         helperDiagnosticsCopied = true
+        helperDiagnosticsFeedbackTask?.cancel()
+        helperDiagnosticsFeedbackTask = Task { @MainActor in
+            try? await Task.sleep(for: .seconds(2))
+            guard !Task.isCancelled else { return }
+            helperDiagnosticsCopied = false
+            helperDiagnosticsFeedbackTask = nil
+        }
     }
 
     private func performControlSessionPrimaryAction(_ presentation: ControlSessionPresentation) {

--- a/Sources/Vifty/ContentView.swift
+++ b/Sources/Vifty/ContentView.swift
@@ -27,9 +27,6 @@ struct ContentView: View {
             mainContent
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .task {
-            model.start()
-        }
     }
 
     private var mainContent: some View {

--- a/Sources/Vifty/MainWindowLayout.swift
+++ b/Sources/Vifty/MainWindowLayout.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 struct MainWindowLayout: Equatable {
-    private static let workbenchMinimumWidth: CGFloat = 1_280
+    private static let workbenchMinimumWidth: CGFloat = 1_440
     private static let workbenchMinimumHeight: CGFloat = 640
     private static let splitMinimumWidth: CGFloat = 980
     private static let splitMinimumHeight: CGFloat = 560

--- a/Sources/Vifty/MenuBarView.swift
+++ b/Sources/Vifty/MenuBarView.swift
@@ -32,9 +32,6 @@ struct MenuBarView: View {
         }
         .padding(14)
         .frame(width: 320)
-        .task {
-            model.start()
-        }
     }
 
     private func perform(_ action: MenuBarPanelAction) {

--- a/Sources/Vifty/SettingsAgentWorkflowView.swift
+++ b/Sources/Vifty/SettingsAgentWorkflowView.swift
@@ -5,6 +5,7 @@ struct SettingsAgentWorkflowView: View {
     @ObservedObject var model: AppModel
     @State private var agentRuleCopied = false
     @State private var agentCommandCopied = false
+    @State private var copiedFeedbackTask: Task<Void, Never>?
 
     var body: some View {
         SettingsCategorySection(title: "Agent Workflows", systemImage: "terminal") {
@@ -45,12 +46,17 @@ struct SettingsAgentWorkflowView: View {
                     .foregroundStyle(.secondary)
             }
         }
+        .onDisappear {
+            copiedFeedbackTask?.cancel()
+            copiedFeedbackTask = nil
+        }
     }
 
     private func copyAgentWorkflowRule() {
         AgentWorkflowSupport.copyAgentRule()
         agentRuleCopied = true
         agentCommandCopied = false
+        scheduleCopiedFeedbackReset()
     }
 
     private func copyAgentWorkflowCommand(
@@ -60,5 +66,17 @@ struct SettingsAgentWorkflowView: View {
         AgentWorkflowSupport.copyWorkloadCommand(template, mode: mode)
         agentRuleCopied = false
         agentCommandCopied = true
+        scheduleCopiedFeedbackReset()
+    }
+
+    private func scheduleCopiedFeedbackReset() {
+        copiedFeedbackTask?.cancel()
+        copiedFeedbackTask = Task { @MainActor in
+            try? await Task.sleep(for: .seconds(2))
+            guard !Task.isCancelled else { return }
+            agentRuleCopied = false
+            agentCommandCopied = false
+            copiedFeedbackTask = nil
+        }
     }
 }

--- a/Sources/Vifty/SettingsGeneralView.swift
+++ b/Sources/Vifty/SettingsGeneralView.swift
@@ -18,6 +18,11 @@ struct SettingsGeneralView: View {
                 Text("Temperature Curve").tag(ModeSelection.curve)
             }
 
+            Text(StartupModePresentation.resolve(model.startupMode).detail)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+
             Toggle("Start Vifty at startup", isOn: launchAtLoginBinding)
                 .help("Open Vifty automatically at macOS login")
 

--- a/Sources/Vifty/StartupModePresentation.swift
+++ b/Sources/Vifty/StartupModePresentation.swift
@@ -1,0 +1,19 @@
+struct StartupModePresentation: Equatable {
+    let detail: String
+    let requiresExplicitApply: Bool
+
+    static func resolve(_ mode: ModeSelection) -> StartupModePresentation {
+        switch mode {
+        case .auto:
+            return StartupModePresentation(
+                detail: "Starts in macOS Auto control.",
+                requiresExplicitApply: false
+            )
+        case .fixed, .curve:
+            return StartupModePresentation(
+                detail: "Preselects this mode as a draft; it does not change fan control at launch. Review the targets and choose Apply.",
+                requiresExplicitApply: true
+            )
+        }
+    }
+}

--- a/Sources/Vifty/ViftyApp.swift
+++ b/Sources/Vifty/ViftyApp.swift
@@ -61,7 +61,6 @@ final class ViftyAppDelegate: NSObject, NSApplicationDelegate {
         statusItemController?.openMainWindow = { [weak self] in
             self?.openMainWindow()
         }
-        model.start()
     }
 
     func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {

--- a/Sources/Vifty/ViftyApp.swift
+++ b/Sources/Vifty/ViftyApp.swift
@@ -26,6 +26,9 @@ struct ViftyApp: App {
         }
         .defaultSize(width: 1180, height: 820)
         .windowResizability(.contentMinSize)
+        .commands {
+            ViftyCommands(model: model, openWindow: openWindow)
+        }
 
         Settings {
             ViftySettingsView(model: model)

--- a/Sources/Vifty/ViftyCommands.swift
+++ b/Sources/Vifty/ViftyCommands.swift
@@ -1,0 +1,23 @@
+import SwiftUI
+
+struct ViftyCommands: Commands {
+    @ObservedObject var model: AppModel
+    let openWindow: OpenWindowAction
+
+    var body: some Commands {
+        CommandGroup(after: .appInfo) {
+            Button("Open Vifty") {
+                openWindow(id: "main")
+            }
+            .keyboardShortcut("0", modifiers: .command)
+        }
+
+        CommandMenu("Control") {
+            Button("Restore Auto") {
+                model.restoreAuto()
+            }
+            .disabled(!model.canRequestRestoreAuto)
+            .help("Return fan control to macOS Auto. No keyboard shortcut is assigned to avoid accidental activation.")
+        }
+    }
+}

--- a/Sources/Vifty/ViftyStatusItemController.swift
+++ b/Sources/Vifty/ViftyStatusItemController.swift
@@ -113,7 +113,6 @@ final class ViftyStatusItemController: NSObject {
 
     private func showPopover() {
         guard let button = statusItem.button else { return }
-        model.start()
         scheduleTelemetryPrimeIfNeeded(policy: Self.popoverPrimePolicy)
         popover.show(relativeTo: button.bounds, of: button, preferredEdge: .minY)
         NSApplication.shared.activate(ignoringOtherApps: true)
@@ -122,7 +121,6 @@ final class ViftyStatusItemController: NSObject {
     private func primeStatusItemUntilTelemetryResolved(
         policy: MenuBarTelemetryPrimePolicy
     ) async {
-        model.start()
         for attempt in 1...policy.maxAttempts {
             guard policy.shouldAttempt(
                 attempt,

--- a/Tests/ViftyCoreTests/AppModelTests.swift
+++ b/Tests/ViftyCoreTests/AppModelTests.swift
@@ -2733,7 +2733,7 @@ final class AppModelTests: XCTestCase {
         XCTAssertEqual(loaded.codexUsageDisplayPreferences.displayStyle, .text)
     }
 
-    func testStartupFixedModeAppliesOnceThroughManualPreflight() async throws {
+    func testNonAutoStartupPreferenceCreatesDraftWithoutFanWrite() async throws {
         let preferencesURL = temporaryPreferencesPath()
         let store = AppPreferencesStore(url: preferencesURL, legacyDefaults: nil)
         try store.saveThrowing(AppPreferences(
@@ -2760,9 +2760,10 @@ final class AppModelTests: XCTestCase {
         await model.applyStartupModePreferenceIfNeeded()
 
         XCTAssertEqual(model.selectedMode, .fixed)
-        XCTAssertEqual(model.controlState.mode, .fixedRPM(3600))
+        XCTAssertTrue(model.hasPendingFanControlChanges)
+        XCTAssertEqual(model.controlState.mode, .auto)
         let appliedCommands = await hardware.appliedCommands
-        XCTAssertEqual(appliedCommands, [FanCommand(fanID: 0, mode: .fixedRPM(3600))])
+        XCTAssertEqual(appliedCommands, [])
     }
 
     func testHelperFailureNotificationFiresOnAttentionTransitionWhenEnabled() async throws {

--- a/Tests/ViftyCoreTests/AppSourceRegressionTests.swift
+++ b/Tests/ViftyCoreTests/AppSourceRegressionTests.swift
@@ -14,6 +14,16 @@ final class AppSourceRegressionTests: XCTestCase {
         XCTAssertFalse(status.contains("model.start()"))
     }
 
+    func testCopyFeedbackResetsInsteadOfStayingVisibleForever() throws {
+        let settings = try read("Sources/Vifty/SettingsAgentWorkflowView.swift")
+        let content = try read("Sources/Vifty/ContentView.swift")
+
+        XCTAssertTrue(settings.contains("try? await Task.sleep(for: .seconds(2))"))
+        XCTAssertTrue(settings.contains("agentRuleCopied = false"))
+        XCTAssertTrue(settings.contains("agentCommandCopied = false"))
+        XCTAssertTrue(content.contains("helperDiagnosticsCopied = false"))
+    }
+
     func testExactCurvePointSlidersExposeDistinctUnitsAndHints() throws {
         let fanControlPanel = try read("Sources/Vifty/FanControlPanel.swift")
 

--- a/Tests/ViftyCoreTests/AppSourceRegressionTests.swift
+++ b/Tests/ViftyCoreTests/AppSourceRegressionTests.swift
@@ -2,6 +2,18 @@ import Foundation
 import XCTest
 
 final class AppSourceRegressionTests: XCTestCase {
+    func testAppOwnsTheOnlyProductionPollingStart() throws {
+        let app = try read("Sources/Vifty/ViftyApp.swift")
+        let content = try read("Sources/Vifty/ContentView.swift")
+        let menu = try read("Sources/Vifty/MenuBarView.swift")
+        let status = try read("Sources/Vifty/ViftyStatusItemController.swift")
+
+        XCTAssertEqual(app.components(separatedBy: "model.start()").count - 1, 1)
+        XCTAssertFalse(content.contains("model.start()"))
+        XCTAssertFalse(menu.contains("model.start()"))
+        XCTAssertFalse(status.contains("model.start()"))
+    }
+
     func testExactCurvePointSlidersExposeDistinctUnitsAndHints() throws {
         let fanControlPanel = try read("Sources/Vifty/FanControlPanel.swift")
 

--- a/Tests/ViftyCoreTests/MainWindowLayoutTests.swift
+++ b/Tests/ViftyCoreTests/MainWindowLayoutTests.swift
@@ -62,16 +62,17 @@ final class MainWindowLayoutTests: XCTestCase {
         XCTAssertEqual(layout.telemetryPaneMaxWidth, .infinity)
     }
 
-    func testWorkbenchKeepsTelemetryUsableAtEntryWidth() {
+    func test1280ClassDisplayUsesSplitLayoutInsteadOfSparseWorkbench() {
         let layout = MainWindowLayout.resolve(width: 1280, height: 720)
 
-        XCTAssertEqual(layout.mode, .workbench)
-        XCTAssertEqual(layout.controlPaneWidth, 320)
-        XCTAssertGreaterThanOrEqual(layout.editorPaneMinWidth, 460)
+        XCTAssertEqual(layout.mode, .split)
+        XCTAssertFalse(layout.compactTelemetry)
+        XCTAssertGreaterThanOrEqual(layout.controlPaneWidth, 480)
         XCTAssertGreaterThanOrEqual(layout.telemetryPaneMinWidth, 420)
-        XCTAssertLessThanOrEqual(
-            layout.controlPaneWidth + layout.editorPaneMinWidth + layout.telemetryPaneMinWidth,
-            1_200
-        )
+    }
+
+    func testWorkbenchBeginsAt1440Points() {
+        XCTAssertEqual(MainWindowLayout.resolve(width: 1439, height: 820).mode, .split)
+        XCTAssertEqual(MainWindowLayout.resolve(width: 1440, height: 820).mode, .workbench)
     }
 }

--- a/Tests/ViftyCoreTests/SettingsSceneSourceTests.swift
+++ b/Tests/ViftyCoreTests/SettingsSceneSourceTests.swift
@@ -33,6 +33,7 @@ final class SettingsSceneSourceTests: XCTestCase {
         XCTAssertTrue(general.contains("Text(\"Auto\").tag(ModeSelection.auto)"))
         XCTAssertTrue(general.contains("Text(\"Fixed RPM\").tag(ModeSelection.fixed)"))
         XCTAssertTrue(general.contains("Text(\"Temperature Curve\").tag(ModeSelection.curve)"))
+        XCTAssertTrue(general.contains("StartupModePresentation.resolve(model.startupMode).detail"))
         XCTAssertFalse(general.contains("Text(mode.rawValue)"))
         XCTAssertTrue(menuBar.contains("Picker(\"Menu bar\", selection: $model.menuBarDisplayMode)"))
         XCTAssertTrue(notifications.contains("Toggle(\"Helper failure\", isOn: $model.notificationSettings.helperFailure)"))

--- a/Tests/ViftyCoreTests/StartupModePresentationTests.swift
+++ b/Tests/ViftyCoreTests/StartupModePresentationTests.swift
@@ -1,0 +1,21 @@
+import XCTest
+@testable import Vifty
+
+final class StartupModePresentationTests: XCTestCase {
+    func testAutoExplainsSafeSystemControl() {
+        let presentation = StartupModePresentation.resolve(.auto)
+
+        XCTAssertEqual(presentation.detail, "Starts in macOS Auto control.")
+        XCTAssertFalse(presentation.requiresExplicitApply)
+    }
+
+    func testFixedAndCurveRequireExplicitApply() {
+        for mode in [ModeSelection.fixed, .curve] {
+            let presentation = StartupModePresentation.resolve(mode)
+
+            XCTAssertTrue(presentation.requiresExplicitApply)
+            XCTAssertTrue(presentation.detail.contains("Apply"))
+            XCTAssertTrue(presentation.detail.contains("does not change fan control at launch"))
+        }
+    }
+}

--- a/Tests/ViftyCoreTests/ViftyCommandsSourceTests.swift
+++ b/Tests/ViftyCoreTests/ViftyCommandsSourceTests.swift
@@ -1,0 +1,29 @@
+import Foundation
+import XCTest
+
+final class ViftyCommandsSourceTests: XCTestCase {
+    func testCommandsRouteThroughAppModelAndRestoreHasNoShortcut() throws {
+        let source = try read("Sources/Vifty/ViftyCommands.swift")
+
+        XCTAssertTrue(source.contains("model.restoreAuto()"))
+        XCTAssertTrue(source.contains("openWindow(id: \"main\")"))
+        XCTAssertTrue(source.contains(".keyboardShortcut(\"0\", modifiers: .command)"))
+
+        let restoreBlock = source.components(separatedBy: "Button(\"Restore Auto\")").dropFirst().first ?? ""
+        XCTAssertFalse(restoreBlock.prefix(300).contains("keyboardShortcut"))
+        XCTAssertFalse(source.contains("FanControlCoordinator("))
+        XCTAssertFalse(source.contains("SMCClient"))
+    }
+
+    private func read(_ relativePath: String) throws -> String {
+        let testFile = URL(fileURLWithPath: #filePath)
+        let repositoryRoot = testFile
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        return try String(
+            contentsOf: repositoryRoot.appendingPathComponent(relativePath),
+            encoding: .utf8
+        )
+    }
+}

--- a/docs/superpowers/plans/2026-07-12-vifty-v1.3-completion-and-hardening.md
+++ b/docs/superpowers/plans/2026-07-12-vifty-v1.3-completion-and-hardening.md
@@ -1,0 +1,891 @@
+# Vifty v1.3.0 Completion And Hardening Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Finish Vifty v1.3.0 as a safe, native, accessible macOS operator tool, close the remaining lifecycle/layout/startup/evidence gaps, and leave the largest maintainability debts behind explicit post-release gates rather than destabilizing the trusted release candidate.
+
+**Architecture:** Keep `AppModel` and `FanControlCoordinator` as the existing control authorities for v1.3, but make app startup single-owner, make non-Auto startup preferences draft-only, and route new macOS commands through existing safe model actions. Refine the pure layout policy so 1280-class displays use the useful two-pane form, strengthen feedback/accessibility through small presentation types, and defer large model decomposition until after the v1.3 trusted binary is published.
+
+**Tech Stack:** Swift 6, Swift Package Manager, SwiftUI, narrow AppKit status-item/window interop, macOS 15+, XCTest, existing `make verify` / `make verify-full` trust gates, GitHub Actions, Developer ID signing, notarization, stapling, Homebrew cask checksum handoff, and existing Vifty evidence-review scripts.
+
+## Global Constraints
+
+- Repository root: `/Users/reidar/Projectos/Vifty`.
+- Minimum deployment target remains macOS 15.
+- Before long build/test loops, run `df -h /System/Volumes/Data`; stop below `30Gi` free.
+- Use `swift test --scratch-path "$PWD/.build"`, `swift build --scratch-path "$PWD/.build"`, and repository-local `.derivedData` if Xcode is required.
+- Do not invoke helper repair/install, fan writes, cooling leases, Auto restoration, Fixed/Curve Apply, or other hardware-mutating actions during automated implementation or review.
+- Preserve daemon-first fail-closed writes, `FanCurve.clamp()` authority, SMC write allowlisting, unclean-exit recovery, agent lease limits, unsupported-hardware blocks, read-only diagnostics, private persistence permissions, and release TeamID enforcement.
+- Do not edit `Sources/ViftyCore/SMCClient.swift`, `Sources/ViftyCore/RealMacHardwareService.swift`, `Sources/ViftyCore/HardwareService.swift`, `Sources/ViftyDaemon/main.swift`, or `Sources/ViftyCore/AgentControlPolicy.swift` for these UI/lifecycle tasks.
+- Keep `v1.2.0` immutable. Version, cask, tag, and release metadata move to `1.3.0` only in Task 7 after the code branch is merged and verified.
+- Use TDD for every behavior change, make one focused commit per task, and run `git diff --check` before each commit.
+- Preserve explicit non-claims in implementation reports and Obsidian logs.
+
+---
+
+## Scope And Release Gates
+
+### Required before the v1.3.0 tag
+
+1. Single-owner polling lifecycle.
+2. Draft-only non-Auto startup defaults.
+3. Useful 1280-class responsive allocation.
+4. Native macOS commands routed through safe actions.
+5. Copy feedback and final accessibility/evidence closure.
+6. Full local and CI verification.
+7. Exact-SHA Developer ID release pipeline and installed-release review.
+
+### Explicitly deferred until after the trusted v1.3.0 release
+
+1. Splitting the 2,826-line `AppModel` into multiple state owners.
+2. Breaking the 5,178-line `AppModelTests` file into suites.
+3. Replacing most of the 1,048-line source-string regression suite.
+4. New telemetry domains, persistence, generic system-monitor features, Sparkle, or broad Liquid Glass adoption.
+
+The deferred work is included as Task 8 so it is not lost, but it must not block or destabilize the v1.3 release candidate.
+
+## Verified Starting Evidence
+
+- Branch: `codex/v1.3-operator-clarity` at `6f4bdd276df5791d022c390daa5ddd211aadcfa6`.
+- PR: `#6`, open, ready, mergeable.
+- CI: run `29205186081` passed.
+- Local full gate: `1062/1062` tests plus warnings-as-errors build, app assembly, plist/resources, and strict ad-hoc codesign passed.
+- Worktree was clean before this plan was added.
+- Compact `780 x 480` evidence is usable and scrollable.
+- Widest available `1282 x 768` evidence exposes a three-pane allocation with a compressed safety rail and low-value empty editor space while Auto/helper attention is active.
+- Telemetry window labels derive from sample timestamps rather than assuming a fixed polling cadence.
+- Antigravity model discovery passed, but the deep plan run produced no review because all three configured Claude accounts were cooling down. No external-model finding is treated as evidence.
+
+## File Structure
+
+Create before v1.3:
+
+- `Sources/Vifty/ViftyCommands.swift` — native app/control/support commands routed to `AppModel` and `openWindow`.
+- `Sources/Vifty/StartupModePresentation.swift` — pure startup-default safety text and draft-only policy.
+- `Tests/ViftyCoreTests/StartupModePresentationTests.swift` — startup policy and copy tests.
+- `Tests/ViftyCoreTests/ViftyCommandsSourceTests.swift` — narrow source contract for safe command routing and absence of a Restore Auto shortcut.
+
+Modify before v1.3:
+
+- `Sources/Vifty/ViftyApp.swift` — single lifecycle start and command installation.
+- `Sources/Vifty/AppModel.swift` — draft-only startup preference application and command capability properties.
+- `Sources/Vifty/ContentView.swift` — remove child lifecycle start.
+- `Sources/Vifty/MenuBarView.swift` — remove child lifecycle start.
+- `Sources/Vifty/ViftyStatusItemController.swift` — remove lifecycle start from status-item operations.
+- `Sources/Vifty/SettingsGeneralView.swift` — safety explanation for startup defaults.
+- `Sources/Vifty/MainWindowLayout.swift` — move the workbench breakpoint beyond 1280-class displays.
+- `Tests/ViftyCoreTests/AppModelTests.swift` — lifecycle/startup behavior tests.
+- `Tests/ViftyCoreTests/MainWindowLayoutTests.swift` — 1280 and wide allocation tests.
+- `Tests/ViftyCoreTests/SettingsSceneSourceTests.swift` — Settings safety-copy contract.
+- `Tests/ViftyCoreTests/AppSourceRegressionTests.swift` — remove obsolete multiple-start expectations; retain only narrow safety checks.
+- `Sources/Vifty/SettingsAgentWorkflowView.swift` — bounded copy-success feedback.
+- `Sources/Vifty/TelemetryEvidencePanel.swift` — only if the final clean AX readback still shows duplicate labels.
+- `CHANGELOG.md` — final user-visible Unreleased notes.
+- `Resources/Info.plist`, `Casks/vifty.rb`, `.github/workflows/release.yml` — Task 7 version alignment only.
+
+Create after v1.3:
+
+- `Sources/Vifty/FanControlSessionController.swift` — extracted fan-control draft/apply/session orchestration.
+- `Sources/Vifty/MenuBarPresentationProvider.swift` — extracted menu/status-item presentation calculations.
+- `Sources/Vifty/HelperHealthPresentation.swift` — pure helper-health state and recovery presentation.
+- `Tests/ViftyCoreTests/FanControlSessionControllerTests.swift`.
+- `Tests/ViftyCoreTests/MenuBarPresentationProviderTests.swift`.
+- `Tests/ViftyCoreTests/HelperHealthPresentationTests.swift`.
+
+---
+
+### Task 1: Make App Polling Lifecycle Single-Owner
+
+**Files:**
+- Modify: `Sources/Vifty/ViftyApp.swift:8-66`
+- Modify: `Sources/Vifty/ContentView.swift:28-32`
+- Modify: `Sources/Vifty/MenuBarView.swift:33-37`
+- Modify: `Sources/Vifty/ViftyStatusItemController.swift:108-129`
+- Modify: `Tests/ViftyCoreTests/AppSourceRegressionTests.swift:531-538`
+- Test: `Tests/ViftyCoreTests/AppModelTests.swift`
+
+**Interfaces:**
+- Consumes: existing idempotent `AppModel.start()` and `AppModel.primeMenuBarStatusItemTelemetry(maxAttempts:retryDelay:)`.
+- Produces: exactly one production `model.start()` call in `ViftyApp.init()`; views and status-item actions never own polling lifecycle.
+
+- [ ] **Step 1: Write a failing source contract for one lifecycle owner**
+
+Replace the broad `model.start()` source assertion with:
+
+```swift
+func testAppOwnsTheOnlyProductionPollingStart() throws {
+    let app = try read("Sources/Vifty/ViftyApp.swift")
+    let content = try read("Sources/Vifty/ContentView.swift")
+    let menu = try read("Sources/Vifty/MenuBarView.swift")
+    let status = try read("Sources/Vifty/ViftyStatusItemController.swift")
+
+    XCTAssertEqual(app.components(separatedBy: "model.start()").count - 1, 1)
+    XCTAssertFalse(content.contains("model.start()"))
+    XCTAssertFalse(menu.contains("model.start()"))
+    XCTAssertFalse(status.contains("model.start()"))
+}
+```
+
+- [ ] **Step 2: Run the focused source test and confirm RED**
+
+Run:
+
+```bash
+swift test --scratch-path "$PWD/.build" --filter AppSourceRegressionTests/testAppOwnsTheOnlyProductionPollingStart
+```
+
+Expected: FAIL because `model.start()` appears in the app delegate, content view, menu-bar view, and status-item controller.
+
+- [ ] **Step 3: Remove secondary lifecycle starts**
+
+Keep this in `ViftyApp.init()`:
+
+```swift
+@MainActor
+init() {
+    let model = AppModel()
+    _model = StateObject(wrappedValue: model)
+    appDelegate.model = model
+    model.start()
+}
+```
+
+Remove `.task { model.start() }` from `ContentView`, remove the equivalent task from `MenuBarView`, remove `model.start()` from `applicationDidFinishLaunching`, and remove both status-item action calls. Do not change telemetry priming; it remains a read-only `pollOnce()` optimization after the app-owned start.
+
+- [ ] **Step 4: Run lifecycle and polling tests**
+
+Run:
+
+```bash
+swift test --scratch-path "$PWD/.build" --filter AppSourceRegressionTests/testAppOwnsTheOnlyProductionPollingStart
+swift test --scratch-path "$PWD/.build" --filter AppModelTests
+```
+
+Expected: both commands PASS; existing repeated-call idempotency tests remain green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/Vifty/ViftyApp.swift Sources/Vifty/ContentView.swift Sources/Vifty/MenuBarView.swift Sources/Vifty/ViftyStatusItemController.swift Tests/ViftyCoreTests/AppSourceRegressionTests.swift Tests/ViftyCoreTests/AppModelTests.swift
+git diff --cached --check
+git commit -m "refactor: centralize app polling lifecycle"
+```
+
+---
+
+### Task 2: Make Non-Auto Startup Defaults Draft-Only
+
+**Files:**
+- Create: `Sources/Vifty/StartupModePresentation.swift`
+- Create: `Tests/ViftyCoreTests/StartupModePresentationTests.swift`
+- Modify: `Sources/Vifty/AppModel.swift:498-507`
+- Modify: `Sources/Vifty/SettingsGeneralView.swift:13-22`
+- Modify: `Tests/ViftyCoreTests/AppModelTests.swift:2741-2764`
+- Modify: `Tests/ViftyCoreTests/SettingsSceneSourceTests.swift:28-35`
+
+**Interfaces:**
+- Consumes: `ModeSelection`, `AppModel.markFanControlDraftPending()`, existing explicit Apply flow.
+- Produces: `StartupModePresentation.resolve(_:) -> StartupModePresentation`; startup preference preselects Fixed/Curve but never writes fans until Apply.
+
+- [ ] **Step 1: Write failing startup policy tests**
+
+Create:
+
+```swift
+import XCTest
+@testable import Vifty
+
+final class StartupModePresentationTests: XCTestCase {
+    func testAutoExplainsSafeSystemControl() {
+        let presentation = StartupModePresentation.resolve(.auto)
+        XCTAssertEqual(presentation.detail, "Starts in macOS Auto control.")
+        XCTAssertFalse(presentation.requiresExplicitApply)
+    }
+
+    func testFixedAndCurveRequireExplicitApply() {
+        for mode in [ModeSelection.fixed, .curve] {
+            let presentation = StartupModePresentation.resolve(mode)
+            XCTAssertTrue(presentation.requiresExplicitApply)
+            XCTAssertTrue(presentation.detail.contains("Apply"))
+            XCTAssertTrue(presentation.detail.contains("does not change fan control at launch"))
+        }
+    }
+}
+```
+
+Replace the existing startup-write test with:
+
+```swift
+func testNonAutoStartupPreferenceCreatesDraftWithoutFanWrite() async {
+    let store = AppPreferencesStore(url: temporaryPreferencesPath())
+    try? store.save(AppPreferences(startupMode: .fixed))
+    let hardware = AppModelFakeHardware(snapshot: agentHardwareSnapshot())
+    let model = makeModel(hardware: hardware, preferencesStore: store)
+    model.fixedRPM = 3600
+
+    await model.applyStartupModePreferenceIfNeeded()
+    await model.applyStartupModePreferenceIfNeeded()
+
+    XCTAssertEqual(model.selectedMode, .fixed)
+    XCTAssertTrue(model.hasPendingFanControlChanges)
+    XCTAssertEqual(model.controlState.mode, .auto)
+    XCTAssertEqual(await hardware.appliedCommands, [])
+}
+```
+
+- [ ] **Step 2: Run focused tests and confirm RED**
+
+```bash
+swift test --scratch-path "$PWD/.build" --filter StartupModePresentationTests
+swift test --scratch-path "$PWD/.build" --filter AppModelTests/testNonAutoStartupPreferenceCreatesDraftWithoutFanWrite
+```
+
+Expected: compilation failure for the new presentation type and behavioral failure because startup currently calls `applyCurrentModeSelection()`.
+
+- [ ] **Step 3: Implement the pure presentation and draft-only policy**
+
+Create:
+
+```swift
+struct StartupModePresentation: Equatable {
+    let detail: String
+    let requiresExplicitApply: Bool
+
+    static func resolve(_ mode: ModeSelection) -> StartupModePresentation {
+        switch mode {
+        case .auto:
+            return StartupModePresentation(
+                detail: "Starts in macOS Auto control.",
+                requiresExplicitApply: false
+            )
+        case .fixed, .curve:
+            return StartupModePresentation(
+                detail: "Preselects this mode as a draft; it does not change fan control at launch. Review the targets and choose Apply.",
+                requiresExplicitApply: true
+            )
+        }
+    }
+}
+```
+
+Change startup application to:
+
+```swift
+func applyStartupModePreferenceIfNeeded() async {
+    guard !startupModeApplied else { return }
+    startupModeApplied = true
+    selectedMode = startupMode
+    guard startupMode != .auto else { return }
+    if snapshot == nil {
+        await pollOnce()
+        selectedMode = startupMode
+    }
+    markFanControlDraftPending()
+}
+```
+
+Add beneath the picker:
+
+```swift
+Text(StartupModePresentation.resolve(model.startupMode).detail)
+    .font(.caption)
+    .foregroundStyle(.secondary)
+    .fixedSize(horizontal: false, vertical: true)
+```
+
+- [ ] **Step 4: Run startup, settings, and control-session tests**
+
+```bash
+swift test --scratch-path "$PWD/.build" --filter StartupModePresentationTests
+swift test --scratch-path "$PWD/.build" --filter AppModelTests
+swift test --scratch-path "$PWD/.build" --filter SettingsSceneSourceTests
+swift test --scratch-path "$PWD/.build" --filter ControlSessionPresentationTests
+```
+
+Expected: all PASS; no test records a fan command during startup preference application.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/Vifty/StartupModePresentation.swift Sources/Vifty/AppModel.swift Sources/Vifty/SettingsGeneralView.swift Tests/ViftyCoreTests/StartupModePresentationTests.swift Tests/ViftyCoreTests/AppModelTests.swift Tests/ViftyCoreTests/SettingsSceneSourceTests.swift
+git diff --cached --check
+git commit -m "fix: require apply for manual startup defaults"
+```
+
+---
+
+### Task 3: Use Two Panes On 1280-Class Displays
+
+**Files:**
+- Modify: `Sources/Vifty/MainWindowLayout.swift:3-68`
+- Modify: `Tests/ViftyCoreTests/MainWindowLayoutTests.swift`
+- Verify: `Sources/Vifty/ContentView.swift:35-130`
+
+**Interfaces:**
+- Consumes: existing `MainWindowLayout.resolve(width:height:)` and section placement.
+- Produces: workbench begins at `1_440` points; `1_280 x 720` uses split mode with a readable control pane and telemetry pane.
+
+- [ ] **Step 1: Replace the entry-width test with expected two-pane behavior**
+
+```swift
+func test1280ClassDisplayUsesSplitLayoutInsteadOfSparseWorkbench() {
+    let layout = MainWindowLayout.resolve(width: 1280, height: 720)
+
+    XCTAssertEqual(layout.mode, .split)
+    XCTAssertFalse(layout.compactTelemetry)
+    XCTAssertGreaterThanOrEqual(layout.controlPaneWidth, 480)
+    XCTAssertGreaterThanOrEqual(layout.telemetryPaneMinWidth, 420)
+}
+
+func testWorkbenchBeginsAt1440Points() {
+    XCTAssertEqual(MainWindowLayout.resolve(width: 1439, height: 820).mode, .split)
+    XCTAssertEqual(MainWindowLayout.resolve(width: 1440, height: 820).mode, .workbench)
+}
+```
+
+- [ ] **Step 2: Run the layout suite and confirm RED**
+
+```bash
+swift test --scratch-path "$PWD/.build" --filter MainWindowLayoutTests
+```
+
+Expected: FAIL because the current threshold is `1_280`.
+
+- [ ] **Step 3: Change only the workbench threshold**
+
+```swift
+private static let workbenchMinimumWidth: CGFloat = 1_440
+```
+
+Do not add mode-dependent section relocation in v1.3. The existing split placement already keeps Safety/Mode and Fan Control together and gives Telemetry the second pane.
+
+- [ ] **Step 4: Run layout and placement suites**
+
+```bash
+swift test --scratch-path "$PWD/.build" --filter MainWindowLayoutTests
+swift test --scratch-path "$PWD/.build" --filter MainWindowSectionPlacementTests
+swift test --scratch-path "$PWD/.build" --filter TelemetryLayoutPolicyTests
+```
+
+Expected: all PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/Vifty/MainWindowLayout.swift Tests/ViftyCoreTests/MainWindowLayoutTests.swift
+git diff --cached --check
+git commit -m "fix: reserve workbench layout for wider displays"
+```
+
+---
+
+### Task 4: Add Native macOS Commands Without Unsafe Shortcuts
+
+**Files:**
+- Create: `Sources/Vifty/ViftyCommands.swift`
+- Create: `Tests/ViftyCoreTests/ViftyCommandsSourceTests.swift`
+- Modify: `Sources/Vifty/ViftyApp.swift:18-32`
+- Modify: `Sources/Vifty/AppModel.swift` near `restoreAuto()`
+
+**Interfaces:**
+- Consumes: `AppModel.restoreAuto()`, `ControlSessionPresentation.primaryAction`, SwiftUI `openWindow(id:)`.
+- Produces: `AppModel.canRequestRestoreAuto`, `ViftyCommands`, Command-0 Open Vifty, and a no-shortcut Restore Auto command.
+
+- [ ] **Step 1: Write the failing safe-command source test**
+
+```swift
+import XCTest
+@testable import Vifty
+
+final class ViftyCommandsSourceTests: XCTestCase {
+    func testCommandsRouteThroughAppModelAndRestoreHasNoShortcut() throws {
+        let source = try String(contentsOfFile: "Sources/Vifty/ViftyCommands.swift", encoding: .utf8)
+
+        XCTAssertTrue(source.contains("model.restoreAuto()"))
+        XCTAssertTrue(source.contains("openWindow(id: \"main\")"))
+        XCTAssertTrue(source.contains(".keyboardShortcut(\"0\", modifiers: .command)"))
+
+        let restoreBlock = source.components(separatedBy: "Button(\"Restore Auto\")").dropFirst().first ?? ""
+        XCTAssertFalse(restoreBlock.prefix(300).contains("keyboardShortcut"))
+        XCTAssertFalse(source.contains("FanControlCoordinator("))
+        XCTAssertFalse(source.contains("SMCClient"))
+    }
+}
+```
+
+- [ ] **Step 2: Run the focused test and confirm RED**
+
+```bash
+swift test --scratch-path "$PWD/.build" --filter ViftyCommandsSourceTests
+```
+
+Expected: FAIL because `ViftyCommands.swift` does not exist.
+
+- [ ] **Step 3: Add command capability and commands**
+
+Add to `AppModel`:
+
+```swift
+var canRequestRestoreAuto: Bool {
+    controlSessionPresentation.primaryAction == .restoreAuto
+        || controlState.manualControlActive
+        || controlState.mode != .auto
+        || agentControlStatus?.activeLease != nil
+}
+```
+
+Create:
+
+```swift
+import SwiftUI
+
+struct ViftyCommands: Commands {
+    @ObservedObject var model: AppModel
+    let openWindow: OpenWindowAction
+
+    var body: some Commands {
+        CommandGroup(after: .appInfo) {
+            Button("Open Vifty") {
+                openWindow(id: "main")
+            }
+            .keyboardShortcut("0", modifiers: .command)
+        }
+
+        CommandMenu("Control") {
+            Button("Restore Auto") {
+                model.restoreAuto()
+            }
+            .disabled(!model.canRequestRestoreAuto)
+            .help("Return fan control to macOS Auto. No keyboard shortcut is assigned to avoid accidental activation.")
+        }
+    }
+}
+```
+
+Attach to the main scene:
+
+```swift
+.commands {
+    ViftyCommands(model: model, openWindow: openWindow)
+}
+```
+
+- [ ] **Step 4: Run command, menu, and model tests**
+
+```bash
+swift test --scratch-path "$PWD/.build" --filter ViftyCommandsSourceTests
+swift test --scratch-path "$PWD/.build" --filter ControlSessionPresentationTests
+swift test --scratch-path "$PWD/.build" --filter MenuBarPanelPresentationTests
+swift test --scratch-path "$PWD/.build" --filter AppModelTests
+```
+
+Expected: all PASS. The command test proves no direct coordinator/SMC path and no Restore Auto keyboard shortcut.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/Vifty/ViftyCommands.swift Sources/Vifty/ViftyApp.swift Sources/Vifty/AppModel.swift Tests/ViftyCoreTests/ViftyCommandsSourceTests.swift
+git diff --cached --check
+git commit -m "feat: add safe native macOS commands"
+```
+
+---
+
+### Task 5: Make Copy Feedback Bounded And Accessible
+
+**Files:**
+- Modify: `Sources/Vifty/SettingsAgentWorkflowView.swift:5-55`
+- Modify: `Sources/Vifty/ContentView.swift:7-8,286-291`
+- Test: `Tests/ViftyCoreTests/AppSourceRegressionTests.swift`
+
+**Interfaces:**
+- Consumes: existing clipboard helpers and copied-message constants.
+- Produces: a reusable local `showCopiedFeedback(_:)` pattern that resets after two seconds and announces success through the visible accessibility tree.
+
+- [ ] **Step 1: Add failing source contracts for reset behavior**
+
+```swift
+func testCopyFeedbackResetsInsteadOfStayingVisibleForever() throws {
+    let settings = try read("Sources/Vifty/SettingsAgentWorkflowView.swift")
+    let content = try read("Sources/Vifty/ContentView.swift")
+
+    XCTAssertTrue(settings.contains("try? await Task.sleep(for: .seconds(2))"))
+    XCTAssertTrue(settings.contains("agentRuleCopied = false"))
+    XCTAssertTrue(settings.contains("agentCommandCopied = false"))
+    XCTAssertTrue(content.contains("helperDiagnosticsCopied = false"))
+}
+```
+
+- [ ] **Step 2: Run the focused test and confirm RED**
+
+```bash
+swift test --scratch-path "$PWD/.build" --filter AppSourceRegressionTests/testCopyFeedbackResetsInsteadOfStayingVisibleForever
+```
+
+Expected: FAIL because copied state currently remains true until another action or view recreation.
+
+- [ ] **Step 3: Add cancellable two-second resets**
+
+Add state:
+
+```swift
+@State private var copiedFeedbackTask: Task<Void, Never>?
+```
+
+After setting each copied flag, call:
+
+```swift
+private func scheduleCopiedFeedbackReset() {
+    copiedFeedbackTask?.cancel()
+    copiedFeedbackTask = Task { @MainActor in
+        try? await Task.sleep(for: .seconds(2))
+        guard !Task.isCancelled else { return }
+        agentRuleCopied = false
+        agentCommandCopied = false
+    }
+}
+```
+
+Add `.onDisappear { copiedFeedbackTask?.cancel() }`. Apply the same bounded reset to `helperDiagnosticsCopied` in `ContentView`. Keep the existing visible copied text so VoiceOver receives a normal state change; do not add private AppKit accessibility APIs.
+
+- [ ] **Step 4: Run settings and source tests**
+
+```bash
+swift test --scratch-path "$PWD/.build" --filter AppSourceRegressionTests/testCopyFeedbackResetsInsteadOfStayingVisibleForever
+swift test --scratch-path "$PWD/.build" --filter SettingsSceneSourceTests
+swift test --scratch-path "$PWD/.build" --filter AppSourceRegressionTests
+```
+
+Expected: all PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/Vifty/SettingsAgentWorkflowView.swift Sources/Vifty/ContentView.swift Tests/ViftyCoreTests/AppSourceRegressionTests.swift
+git diff --cached --check
+git commit -m "fix: bound copy confirmation feedback"
+```
+
+---
+
+### Task 6: Close UI, Accessibility, And Documentation Evidence
+
+**Files:**
+- Modify only if evidence fails: `Sources/Vifty/TelemetryEvidencePanel.swift`
+- Modify: `CHANGELOG.md`
+- Create: `.superpowers/sdd/v1.3-final-ui-evidence/` runtime artifacts, not committed unless repository policy explicitly requires them.
+
+**Interfaces:**
+- Consumes: `.build/Vifty.app`, existing screenshot/AX inspection workflow, existing pure layout and presentation tests.
+- Produces: exact evidence manifest for compact, default, 1280-class split, wide workbench, Settings tabs, menu commands, and corrected thermal-pressure AX label.
+
+- [ ] **Step 1: Run focused and fast gates before launching the bundle**
+
+```bash
+df -h /System/Volumes/Data
+swift test --scratch-path "$PWD/.build" --filter MainWindowLayoutTests
+swift test --scratch-path "$PWD/.build" --filter StartupModePresentationTests
+swift test --scratch-path "$PWD/.build" --filter ViftyCommandsSourceTests
+make test-fast SWIFT_BUILD_PATH="$PWD/.build"
+swift build --scratch-path "$PWD/.build" -Xswiftc -warnings-as-errors
+make app SWIFT_BUILD_PATH="$PWD/.build"
+```
+
+Expected: every command exits `0`; test counts are recorded rather than predicted.
+
+- [ ] **Step 2: Inspect only read-only UI states**
+
+Capture:
+
+```text
+780 x 480 compact stacked layout
+1180 x 820 default layout when the display can fit it; otherwise record the display constraint
+1280 x 720 split layout or the closest unclamped frame supported by the display
+1440+ workbench layout when an available display can fit it
+General, Menu Bar, Notifications, and Agent Workflows Settings tabs
+Vifty/Open Vifty and Control/Restore Auto menu presence and disabled state
+```
+
+Do not click Apply, Restore Auto, Repair Helper, fan targets, curve handles, helper actions, agent actions, or cooling actions.
+
+- [ ] **Step 3: Verify accessibility output**
+
+Require these exact semantic outcomes:
+
+```text
+Mode picker exposes one "Mode" label.
+Each temperature row is a selectable button with sensor name, value, and source.
+Curve handles expose temperature/RPM values and keyboard adjustment guidance.
+Thermal pressure trail exposes "Thermal pressure history <summary>" exactly once.
+Restore Auto command has a help description and no keyboard shortcut.
+```
+
+If the thermal label still duplicates, keep the existing outer `.accessibilityElement(children: .ignore)` and one `.accessibilityLabel(...)`; remove only the competing child label proven by the AX tree.
+
+- [ ] **Step 4: Update changelog with final user-visible outcomes**
+
+Add under Unreleased/Changed:
+
+```markdown
+- Centralized app polling ownership, made manual startup defaults draft-only, improved 1280-class pane allocation, and added native Open Vifty and safely gated Restore Auto commands.
+- Made copied support feedback temporary and completed compact, Settings, command-menu, and accessibility evidence for the release candidate.
+```
+
+- [ ] **Step 5: Run full local verification and commit**
+
+```bash
+make verify-full SWIFT_BUILD_PATH="$PWD/.build"
+git diff --check
+git status --short
+git add CHANGELOG.md Sources/Vifty/TelemetryEvidencePanel.swift
+git diff --cached --check
+git commit -m "docs: finalize v1.3 operator evidence"
+```
+
+Stage `TelemetryEvidencePanel.swift` only if Step 3 required a source correction. Expected: full test suite, warnings-as-errors build, app assembly, plist/resource checks, and strict ad-hoc codesign all pass.
+
+---
+
+### Task 7: Merge And Produce The Trusted v1.3.0 Release
+
+**Files:**
+- Modify: `Resources/Info.plist`
+- Modify: `Casks/vifty.rb`
+- Modify: `.github/workflows/release.yml`
+- Modify: `CHANGELOG.md`
+- Generated evidence: `.build/vifty-validation-*`
+
+**Interfaces:**
+- Consumes: green exact-SHA PR, release scripts, Developer ID secrets configured in GitHub, existing v1.2 trusted-release process.
+- Produces: immutable `v1.3.0` tag, notarized/stapled `Vifty-v1.3.0.zip`, checksum, verifier summary, updated cask checksum, and reviewed installed-release evidence.
+
+- [ ] **Step 1: Merge only after exact-SHA CI is green**
+
+```bash
+gh pr checks 6
+gh pr view 6 --json headRefOid,mergeable,state,isDraft
+```
+
+Expected: all required checks pass, `headRefOid` matches the reviewed commit, `mergeable` is `MERGEABLE`, and `isDraft` is false. Merge using the repository’s chosen merge strategy; record the resulting `main` SHA.
+
+- [ ] **Step 2: Create a separate release-prep branch and align version metadata**
+
+```bash
+git switch main
+git pull --ff-only
+git switch -c codex/v1.3.0-release-prep
+```
+
+Set every release authority to `1.3.0`, move Unreleased entries under:
+
+```markdown
+## [1.3.0] - 2026-07-12
+```
+
+Do not change the cask checksum to a fabricated value; keep the validator-approved placeholder shape until the signed artifact exists.
+
+- [ ] **Step 3: Validate release metadata and full source gate**
+
+```bash
+scripts/validate-release-metadata.sh
+make verify-full SWIFT_BUILD_PATH="$PWD/.build"
+scripts/check-release-readiness.sh --mode developer-id --version 1.3.0 --required-source-ref "$(git rev-parse HEAD)"
+```
+
+Expected: metadata and source checks pass. Secret checks report names only, never values.
+
+- [ ] **Step 4: Commit, review, merge, and tag the exact release SHA**
+
+```bash
+git add Resources/Info.plist Casks/vifty.rb .github/workflows/release.yml CHANGELOG.md
+git diff --cached --check
+git commit -m "chore: prepare v1.3.0 release"
+git push -u origin codex/v1.3.0-release-prep
+gh pr create --title "release: prepare v1.3.0" --body-file /tmp/vifty-v1.3.0-release-pr.md
+```
+
+After release-prep CI passes and the PR is merged:
+
+```bash
+git switch main
+git pull --ff-only
+release_sha=$(git rev-parse HEAD)
+git tag -s v1.3.0 "$release_sha" -m "Vifty v1.3.0"
+git push origin v1.3.0
+```
+
+Expected: the tag points to the exact merged release SHA.
+
+- [ ] **Step 5: Verify the published Developer ID artifact**
+
+```bash
+gh run list --workflow Release --limit 5
+scripts/check-release-readiness.sh --mode developer-id --version 1.3.0 --required-source-ref "$(git rev-list -n 1 v1.3.0)"
+scripts/verify-release-artifact.sh --version 1.3.0 --team-id "$VIFTY_RELEASE_TEAM_ID"
+```
+
+Expected: Release workflow passed; signature, TeamID, notarization, stapling, Gatekeeper, bundle version, helper parity, schema resources, artifact checksum, and published assets all pass.
+
+- [ ] **Step 6: Apply the real cask checksum and re-verify**
+
+```bash
+scripts/update-cask-checksum.sh --checksum-file Vifty-v1.3.0.zip.sha256 --version 1.3.0
+scripts/validate-release-metadata.sh
+git add Casks/vifty.rb
+git diff --cached --check
+git commit -m "chore: update v1.3.0 cask checksum"
+```
+
+Push through a normal PR unless the repository’s documented release process explicitly permits direct `main` updates.
+
+- [ ] **Step 7: Collect and review installed release evidence**
+
+```bash
+make validation-evidence \
+  VALIDATION_EVIDENCE_INSTALL_SOURCE=developer-id-release \
+  VALIDATION_EVIDENCE_SOURCE_REF=v1.3.0 \
+  VALIDATION_EVIDENCE_SOURCE_SHA="$(git rev-list -n 1 v1.3.0)"
+
+make validation-evidence-review \
+  VALIDATION_EVIDENCE_BUNDLE=.build/vifty-validation-<captured-timestamp> \
+  VALIDATION_EVIDENCE_REVIEW_MODE=release \
+  VALIDATION_EVIDENCE_REVIEW_SUMMARY=.build/vifty-validation-<captured-timestamp>/review-result.json
+```
+
+Replace `<captured-timestamp>` with the exact directory emitted by the collector. Expected: read-only release review passes with `coolingCommandsRun: false`. Manual Fixed/Curve hardware compatibility remains a separate claim unless independently collected and reviewed.
+
+- [ ] **Step 8: Log exact release evidence**
+
+Record the merge SHA, tag SHA, CI and Release run IDs, artifact URL/checksum, TeamID/signing/notarization/Gatekeeper results, cask commit, installed review-result path, and explicit hardware non-claims in the Vifty project note and daily note.
+
+---
+
+### Task 8: Post-v1.3 Maintainability Refactor
+
+**Files:**
+- Create: `Sources/Vifty/FanControlSessionController.swift`
+- Create: `Sources/Vifty/MenuBarPresentationProvider.swift`
+- Create: `Sources/Vifty/HelperHealthPresentation.swift`
+- Create: `Tests/ViftyCoreTests/FanControlSessionControllerTests.swift`
+- Create: `Tests/ViftyCoreTests/MenuBarPresentationProviderTests.swift`
+- Create: `Tests/ViftyCoreTests/HelperHealthPresentationTests.swift`
+- Modify: `Sources/Vifty/AppModel.swift`
+- Split: `Tests/ViftyCoreTests/AppModelTests.swift`
+- Reduce: `Tests/ViftyCoreTests/AppSourceRegressionTests.swift`
+
+**Interfaces:**
+- Consumes: the published v1.3 behavior as a locked regression baseline.
+- Produces: focused pure presentation/state collaborators while `AppModel` remains the `@MainActor ObservableObject` integration facade.
+
+- [ ] **Step 1: Lock the v1.3 observable behavior before extraction**
+
+Create fixture-based tests for these signatures:
+
+```swift
+struct FanControlSessionController {
+    mutating func markDraftPending(_ draft: FanControlDraft)
+    mutating func beginApply(operationID: UInt64)
+    mutating func finishApply(operationID: UInt64, result: FanControlApplyResult)
+    mutating func restoreAutoConfirmed()
+}
+
+struct MenuBarPresentationProvider {
+    func panel(input: MenuBarPanelInput) -> MenuBarPanelPresentation
+    func statusItem(input: MenuBarStatusInput) -> MenuBarStatusItemPresentation
+}
+
+struct HelperHealthPresentation {
+    static func resolve(
+        daemonReachable: Bool,
+        snapshotHasFans: Bool,
+        visibleError: String?
+    ) -> HelperHealthPresentation
+}
+```
+
+Tests must cover stale operation IDs, Auto preemption, failed Apply preservation, active/expired agent state, helper unreachable/no-fans distinctions, and current menu/status strings.
+
+- [ ] **Step 2: Run the new suites and confirm RED**
+
+```bash
+swift test --scratch-path "$PWD/.build" --filter FanControlSessionControllerTests
+swift test --scratch-path "$PWD/.build" --filter MenuBarPresentationProviderTests
+swift test --scratch-path "$PWD/.build" --filter HelperHealthPresentationTests
+```
+
+Expected: compilation failure because the collaborators do not exist.
+
+- [ ] **Step 3: Extract pure logic without changing public AppModel behavior**
+
+Move only deterministic state transitions and formatting. Keep hardware reads/writes, polling tasks, notifications, preference persistence, and coordinator calls in `AppModel`. Each extraction commit must keep the full pre-existing AppModel test suite green.
+
+- [ ] **Step 4: Split tests by responsibility**
+
+Move tests without rewriting assertions into:
+
+```text
+AppModelPollingTests.swift
+AppModelFanControlTests.swift
+AppModelMenuBarTests.swift
+AppModelHelperHealthTests.swift
+AppModelNotificationTests.swift
+AppModelPreferencesTests.swift
+```
+
+Then reduce `AppSourceRegressionTests` to contracts that cannot be expressed behaviorally: no direct SMC/coordinator creation in UI commands, Settings remains a native scene, required accessibility modifiers exist, and release-boundary files remain untouched by UI changes.
+
+- [ ] **Step 5: Verify after each extraction commit**
+
+```bash
+swift test --scratch-path "$PWD/.build" --filter FanControlSessionControllerTests
+swift test --scratch-path "$PWD/.build" --filter MenuBarPresentationProviderTests
+swift test --scratch-path "$PWD/.build" --filter HelperHealthPresentationTests
+make test-fast SWIFT_BUILD_PATH="$PWD/.build"
+swift build --scratch-path "$PWD/.build" -Xswiftc -warnings-as-errors
+git diff --check
+```
+
+Expected: all pass after every independently reviewable extraction.
+
+- [ ] **Step 6: Commit each collaborator separately**
+
+```bash
+git commit -m "refactor: extract fan control session state"
+git commit -m "refactor: extract menu bar presentation"
+git commit -m "refactor: extract helper health presentation"
+git commit -m "test: split app model suites by responsibility"
+```
+
+Do not combine these into the v1.3 release-prep commit and do not retag v1.3.0 after publication.
+
+---
+
+## Final Self-Review
+
+### Spec coverage
+
+- Lifecycle ownership: Task 1.
+- Startup safety: Task 2.
+- Wide/1280 responsive allocation: Task 3.
+- Native macOS commands: Task 4.
+- Copy feedback and accessibility: Tasks 5-6.
+- Full local/CI/release trust: Tasks 6-7.
+- AppModel/test maintainability debt: Task 8, explicitly post-release.
+- Product-scope guardrails: Global Constraints and deferred list.
+
+### Completeness scan
+
+- Every behavior-changing step includes exact files, code or commands, expected outcomes, and a commit boundary.
+- The release evidence directory uses `<captured-timestamp>` only where the collector generates the value; the step explicitly instructs the implementer to replace it with emitted output.
+
+### Type consistency
+
+- `StartupModePresentation.resolve(_:)` returns `StartupModePresentation` in both production and tests.
+- `AppModel.canRequestRestoreAuto` is consumed only by `ViftyCommands`.
+- Existing `AppModel.restoreAuto()` remains the only command action; no new hardware interface is introduced.
+- `MainWindowLayout.resolve(width:height:)` keeps its existing signature.
+- Post-release collaborators consume existing v1.3 presentation types and do not replace coordinator authority.
+
+## Execution Handoff
+
+Plan execution should start in an isolated worktree created with `superpowers:using-git-worktrees` after PR #6’s merge/branch decision is clear. Use `superpowers:subagent-driven-development` for one fresh worker and two-stage review per task, or `superpowers:executing-plans` for inline batch execution with checkpoints.


### PR DESCRIPTION
## Summary

- centralize polling lifecycle ownership in the app
- make Fixed/Curve startup defaults draft-only until explicit Apply
- use the denser two-pane layout on 1280-class displays
- add native Open Vifty and safely gated Restore Auto commands
- bound copied-support feedback and finalize the v1.3 completion plan

## Safety boundaries

- no SMC write scope, daemon/helper routing, RPM clamp, agent policy, unsupported-hardware, or release-signing boundary changed
- Restore Auto routes through `AppModel` and intentionally has no keyboard shortcut
- no app launch, helper repair/install, fan write, cooling lease, Auto restore, or live Fixed/Curve action was performed

## Verification

- isolated baseline: 705 tests passed
- post-change fast gate: 705 tests passed
- focused lifecycle, startup, layout, command, Settings, and control-session suites passed
- `make verify-full SWIFT_BUILD_PATH="$PWD/.build"`: 1068 tests passed
- warnings-as-errors build, release app assembly, plist/resources, and strict ad-hoc codesign checks passed

## Release posture

Release metadata remains 1.2.0. This PR does not tag, notarize, update the cask, or publish v1.3.0. It is stacked on PR #6 so the diff contains only completion/hardening work.
