### PR TITLE
release: prepare v1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.0] - 2026-07-12
+
 ### Changed
 - Reframed the main window around explicit readiness, fan-control ownership, and one safe next action.
 - Made manual fan edits draft-first with explicit Apply semantics and immediate Auto restoration.

--- a/Casks/vifty.rb
+++ b/Casks/vifty.rb
@@ -1,5 +1,5 @@
 cask "vifty" do
-  version "1.2.0"
+  version "1.3.0"
   sha256 "7b4b6528a696bfb23995c89c994489cf25e6f4b5cdf50242b7f0a21b897ab28e"
 
   url "https://github.com/Reedtrullz/Vifty/releases/download/v#{version}/Vifty-v#{version}.zip"

--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.2.0</string>
+	<string>1.3.0</string>
 	<key>CFBundleVersion</key>
-	<string>4</string>
+	<string>5</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>15.0</string>
 	<key>LSApplicationCategoryType</key>

--- a/Tests/ViftyCoreTests/DocumentationTrustSurfaceTests.swift
+++ b/Tests/ViftyCoreTests/DocumentationTrustSurfaceTests.swift
@@ -424,7 +424,7 @@ final class DocumentationTrustSurfaceTests: XCTestCase {
         let hotfixNotes = try read("docs/release-notes/v1.1.1.md")
         let unsignedDigestBoundary = "The unsigned-dev zip is valid only with its `.sha256` sidecar, and the SHA-256 digest in that sidecar must match the zip bytes."
 
-        XCTAssertTrue(cask.contains("version \"1.2.0\""))
+        XCTAssertTrue(cask.contains("version \"1.3.0\""))
         XCTAssertTrue(cask.contains("sha256 \"7b4b6528a696bfb23995c89c994489cf25e6f4b5cdf50242b7f0a21b897ab28e\""))
         XCTAssertFalse(cask.contains("disable!"))
         XCTAssertTrue(readme.contains("Vifty `v1.2.0` is the current published Developer ID release."))
@@ -486,7 +486,9 @@ final class DocumentationTrustSurfaceTests: XCTestCase {
         XCTAssertTrue(releaseStatus.contains("Known issue: the published `v1.1.0` source/unsigned-dev release predates helper-install and app-polling hardening on `main`"))
         XCTAssertTrue(releaseStatus.contains("Do not retag `v1.1.0`, rebuild `Vifty-v1.1.0-unsigned-dev.zip` from later `main`, or claim the published `v1.1.0` convenience artifact is the official trusted binary."))
         XCTAssertTrue(releaseStatus.contains("The honest remediation is the `v1.1.1` source-first hotfix release"))
-        XCTAssertTrue(releaseStatus.contains("`Resources/Info.plist` and `Casks/vifty.rb` are aligned at `1.2.0`"))
+        XCTAssertTrue(releaseStatus.contains("Release-candidate metadata in `Resources/Info.plist` and `Casks/vifty.rb` is aligned at `1.3.0`"))
+        XCTAssertTrue(releaseStatus.contains("`v1.2.0` remains the latest trusted public artifact"))
+        XCTAssertTrue(releaseStatus.contains("pending the required post-release checksum handoff"))
         XCTAssertTrue(releaseStatus.contains("At `v1.1.1` publication, `Resources/Info.plist` carried `1.1.1` while `Casks/vifty.rb` remained disabled on `1.1.0`"))
         XCTAssertTrue(releaseStatus.contains("Do not update the Homebrew cask checksum for a source-first release, do not re-enable the cask, and do not point Homebrew at unsigned-dev artifacts."))
         XCTAssertTrue(releaseStatus.contains("## Source-First v1.1.1 Operator Checks"))

--- a/docs/release-status.md
+++ b/docs/release-status.md
@@ -24,7 +24,7 @@ Auto-update status: unavailable in `v1.2.0`, source-first, and unsigned-dev buil
 
 Public release facts:
 
-- `Resources/Info.plist` and `Casks/vifty.rb` are aligned at `1.2.0`; the cask uses the published SHA-256 `7b4b6528a696bfb23995c89c994489cf25e6f4b5cdf50242b7f0a21b897ab28e`.
+- Release-candidate metadata in `Resources/Info.plist` and `Casks/vifty.rb` is aligned at `1.3.0`. Until the tagged workflow publishes `Vifty-v1.3.0.zip` and its checksum, `v1.2.0` remains the latest trusted public artifact and the checked-in cask checksum is the prior published SHA-256 pending the required post-release checksum handoff.
 - Source CI run `29160869645` passed on release commit `9bf45f9afc56a36580bede696c479bff0df0cf6a`, and Release run `29161176933` passed all signing, notarization, pre-publication verification, checklist, and publication steps.
 - The GitHub Release publishes `Vifty-v1.2.0.zip`, `Vifty-v1.2.0.zip.sha256`, `Vifty-v1.2.0-artifact-summary.json`, and `Vifty-v1.2.0-release-checklist.md`.
 - The published workflow summary and an independent downloaded-artifact verification both passed with TeamID `X88J3853S2`, no signature skips, and no notarization skips.


### PR DESCRIPTION
## Summary

- align app and cask release metadata at 1.3.0
- increment the bundle build number to 5
- date the v1.3.0 changelog section
- keep release-status copy honest while v1.2.0 remains the latest trusted public artifact pending the tagged workflow and checksum handoff

## Verification

- merged v1.3 code main CI: run 29208720779 passed at `150e825190049cfee28c548165f0988b3a93aa18`
- `scripts/validate-release-metadata.sh`: passed for 1.3.0
- ReleaseMetadataScriptTests: 77 passed
- ReleaseArtifactScriptTests: 15 passed
- DocumentationTrustSurfaceTests release-status slice: passed
- full `swift test --scratch-path "$PWD/.build"`: 1068 passed
- all six required release secret names are configured

## Release boundary

This PR does not create or push the tag. After merge and exact-head CI pass, the signed `v1.3.0` tag will trigger Developer ID signing, notarization, stapling, artifact verification, and GitHub Release publication. The cask checksum must then be replaced with the published v1.3.0 checksum in a follow-up commit.
