### PR TITLE
Fix fan-control state flashing after writes

### DIFF
--- a/Sources/ViftyCore/HardwareService.swift
+++ b/Sources/ViftyCore/HardwareService.swift
@@ -90,9 +90,11 @@ public actor FanControlCoordinator {
         }
         try validate(snapshot)
 
+        let wroteFanState: Bool
         switch state.mode {
         case .auto:
-            if state.manualControlActive || autoRestoreRequested {
+            wroteFanState = state.manualControlActive || autoRestoreRequested
+            if wroteFanState {
                 try await restoreAuto(for: snapshot.fans)
             }
             autoRestoreRequested = false
@@ -102,20 +104,35 @@ public actor FanControlCoordinator {
             state.statusMessage = "Auto"
             uncleanMarker.clear()
         case .fixedRPM(let rpm):
-            try await applyFixedRPM(rpm, snapshot: snapshot)
+            wroteFanState = try await applyFixedRPM(rpm, snapshot: snapshot)
             state.manualControlActive = true
             uncleanMarker.markActive()
         case .temperatureCurve(let curve):
             if fanOverrides.isEmpty {
-                try await applyCurve(curve, snapshot: snapshot)
+                wroteFanState = try await applyCurve(curve, snapshot: snapshot)
             } else {
-                try await applyCurveWithOverrides(curve, fanOverrides: fanOverrides, snapshot: snapshot)
+                wroteFanState = try await applyCurveWithOverrides(curve, fanOverrides: fanOverrides, snapshot: snapshot)
             }
             state.manualControlActive = true
             uncleanMarker.markActive()
         }
 
-        return snapshot
+        guard wroteFanState else { return snapshot }
+
+        let confirmedSnapshot = try await hardware.snapshot()
+        lastObservedSnapshot = confirmedSnapshot
+        if state.mode != .auto, confirmedSnapshot.temperatureSensors.isEmpty {
+            try await restoreAuto(for: confirmedSnapshot.fans)
+            autoRestoreRequested = false
+            state.manualControlActive = false
+            state.lastAppliedRPM = [:]
+            lastManualWriteAtByFanID = [:]
+            state.statusMessage = "Sensor unavailable, restored Auto"
+            uncleanMarker.clear()
+            throw ViftyError.noTemperatureSensors
+        }
+        try validate(confirmedSnapshot)
+        return confirmedSnapshot
     }
 
     public func forceAuto() async -> AutoRestoreResult {
@@ -149,24 +166,28 @@ public actor FanControlCoordinator {
         }
     }
 
-    private func applyFixedRPM(_ rpm: Int, snapshot: HardwareSnapshot) async throws {
+    private func applyFixedRPM(_ rpm: Int, snapshot: HardwareSnapshot) async throws -> Bool {
+        var appliedFanState = false
         for fan in snapshot.fans where fan.controllable {
             let target = FanCurve.clamp(fixedFanTargets[fan.id] ?? rpm, fan.minimumRPM, fan.maximumRPM)
             guard shouldApply(target, to: fan, capturedAt: snapshot.capturedAt) else { continue }
             try await hardware.apply(FanCommand(fanID: fan.id, mode: .fixedRPM(target)), fan: fan)
+            appliedFanState = true
             state.lastAppliedRPM[fan.id] = target
             lastManualWriteAtByFanID[fan.id] = snapshot.capturedAt
         }
         state.statusMessage = fixedFanTargets.isEmpty ? "Fixed \(rpm) RPM" : "Fixed per-fan RPM"
+        return appliedFanState
     }
 
-    private func applyCurve(_ curve: FanCurve, snapshot: HardwareSnapshot) async throws {
+    private func applyCurve(_ curve: FanCurve, snapshot: HardwareSnapshot) async throws -> Bool {
         let sensor = selectedSensor(for: curve, snapshot: snapshot)
         guard let sensor else {
             try await restoreAuto(for: snapshot.fans)
             throw ViftyError.noTemperatureSensors
         }
 
+        var appliedFanState = false
         for fan in snapshot.fans where fan.controllable {
             let target = curve.targetRPM(
                 for: sensor.celsius,
@@ -175,12 +196,14 @@ public actor FanControlCoordinator {
             )
             guard shouldApply(target, to: fan, capturedAt: snapshot.capturedAt) else { continue }
             try await hardware.apply(FanCommand(fanID: fan.id, mode: .fixedRPM(target)), fan: fan)
+            appliedFanState = true
             state.lastAppliedRPM[fan.id] = target
             lastManualWriteAtByFanID[fan.id] = snapshot.capturedAt
         }
 
         state.selectedSensorID = sensor.id
         state.statusMessage = "\(sensor.name) \(sensor.celsius.rounded()) C"
+        return appliedFanState
     }
 
     private func selectedSensor(for curve: FanCurve, snapshot: HardwareSnapshot) -> TemperatureSensor? {
@@ -228,7 +251,8 @@ public actor FanControlCoordinator {
         }
     }
 
-    public func applyCurveWithOverrides(_ curve: FanCurve, fanOverrides: [FanCurveOverride], snapshot: HardwareSnapshot) async throws {
+    @discardableResult
+    public func applyCurveWithOverrides(_ curve: FanCurve, fanOverrides: [FanCurveOverride], snapshot: HardwareSnapshot) async throws -> Bool {
         let sensor = selectedSensor(for: curve, snapshot: snapshot)
         guard let sensor else {
             try await restoreAuto(for: snapshot.fans)
@@ -237,6 +261,7 @@ public actor FanControlCoordinator {
 
         let overridesByID = fanOverridesByID(fanOverrides)
 
+        var appliedFanState = false
         for fan in snapshot.fans where fan.controllable {
             let target: Int
             if let override = overridesByID[fan.id],
@@ -255,12 +280,14 @@ public actor FanControlCoordinator {
             }
             guard shouldApply(target, to: fan, capturedAt: snapshot.capturedAt) else { continue }
             try await hardware.apply(FanCommand(fanID: fan.id, mode: .fixedRPM(target)), fan: fan)
+            appliedFanState = true
             state.lastAppliedRPM[fan.id] = target
             lastManualWriteAtByFanID[fan.id] = snapshot.capturedAt
         }
 
         state.selectedSensorID = sensor.id
         state.statusMessage = "\(sensor.name) \(sensor.celsius.rounded()) C"
+        return appliedFanState
     }
 
     private func fanOverridesByID(_ overrides: [FanCurveOverride]) -> [Int: FanCurveOverride] {

--- a/Tests/ViftyCoreTests/FanControlCoordinatorTests.swift
+++ b/Tests/ViftyCoreTests/FanControlCoordinatorTests.swift
@@ -253,6 +253,39 @@ final class FanControlCoordinatorTests: XCTestCase {
         XCTAssertFalse(marker.wasManualControlActive)
     }
 
+    func testTickReturnsPostWriteHardwareForCurveAndAutoRestore() async throws {
+        let curve = FanCurve(points: [
+            CurvePoint(temperatureCelsius: 50, rpm: 3_000),
+            CurvePoint(temperatureCelsius: 70, rpm: 5_000)
+        ])
+        let hardware = FakeHardware(
+            snapshot: HardwareSnapshot(
+                fans: [Self.fan(currentRPM: 1_500, hardwareMode: .automatic, targetRPM: 1_500)],
+                temperatureSensors: [Self.sensor(60)],
+                modelIdentifier: "MacBookPro18,1",
+                isAppleSilicon: true,
+                isMacBookPro: true
+            ),
+            reflectsCommandsInSnapshot: true
+        )
+        let coordinator = FanControlCoordinator(hardware: hardware, uncleanMarker: Self.marker())
+
+        await coordinator.setMode(.temperatureCurve(curve))
+        let curveSnapshot = try await coordinator.tick()
+
+        XCTAssertEqual(curveSnapshot.fans.first?.hardwareMode, .forced)
+        XCTAssertEqual(curveSnapshot.fans.first?.targetRPM, 4_000)
+
+        await coordinator.setMode(.auto)
+        let autoSnapshot = try await coordinator.tick()
+
+        XCTAssertEqual(autoSnapshot.fans.first?.hardwareMode, .automatic)
+        XCTAssertEqual(autoSnapshot.fans.first?.targetRPM, 1_400)
+        let state = await coordinator.state
+        XCTAssertEqual(state.mode, .auto)
+        XCTAssertFalse(state.manualControlActive)
+    }
+
     func testExplicitAutoSelectionRestoresEvenWhenStateWasAlreadyCleared() async throws {
         let marker = Self.marker()
         let hardware = FakeHardware(
@@ -522,9 +555,11 @@ private actor FakeHardware: HardwareService {
     var appliedCommands: [FanCommand] = []
     var restoredFanIDs: [Int] = []
     var restoreError: Error?
+    let reflectsCommandsInSnapshot: Bool
 
-    init(snapshot: HardwareSnapshot) {
+    init(snapshot: HardwareSnapshot, reflectsCommandsInSnapshot: Bool = false) {
         self.snapshotValue = snapshot
+        self.reflectsCommandsInSnapshot = reflectsCommandsInSnapshot
     }
 
     func snapshot() async throws -> HardwareSnapshot {
@@ -545,6 +580,14 @@ private actor FakeHardware: HardwareService {
 
     func apply(_ command: FanCommand, fan: Fan) async throws {
         appliedCommands.append(command)
+        guard reflectsCommandsInSnapshot,
+              case .fixedRPM(let targetRPM) = command.mode,
+              let fanIndex = snapshotValue.fans.firstIndex(where: { $0.id == fan.id }) else {
+            return
+        }
+        snapshotValue.fans[fanIndex].currentRPM = targetRPM
+        snapshotValue.fans[fanIndex].hardwareMode = .forced
+        snapshotValue.fans[fanIndex].targetRPM = targetRPM
     }
 
     func restoreAuto(fan: Fan) async throws {
@@ -552,5 +595,12 @@ private actor FakeHardware: HardwareService {
             throw restoreError
         }
         restoredFanIDs.append(fan.id)
+        guard reflectsCommandsInSnapshot,
+              let fanIndex = snapshotValue.fans.firstIndex(where: { $0.id == fan.id }) else {
+            return
+        }
+        snapshotValue.fans[fanIndex].currentRPM = fan.minimumRPM
+        snapshotValue.fans[fanIndex].hardwareMode = .automatic
+        snapshotValue.fans[fanIndex].targetRPM = fan.minimumRPM
     }
 }


### PR DESCRIPTION
## Summary
- return a fresh hardware snapshot after Fixed, Curve, or Auto writes
- stop the UI from evaluating newly applied control state against stale pre-write telemetry
- add regression coverage for Curve activation and Auto restoration

## User-visible defect
During a supervised v1.3.0 Curve smoke test, Safety & Mode flashed between active, pending, and drift-attention states. Restore Auto could appear successful briefly before Curve was reasserted.

## Verification
- `make verify-full SWIFT_BUILD_PATH="$PWD/.build"`
- 1,069 tests passed
- warnings-as-errors build passed
- release app bundle, plist, and code-sign checks passed
- `git diff --check`

## Safety
The test uses a fake hardware service. No automated UI clicks or additional fan writes were used to validate this code change.
