### PR TITLE
Prepare v1.3.1 patch release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.1] - 2026-07-13
+
+### Fixed
+- Confirm fan hardware state after Fixed, Curve, and Auto writes so the UI no longer evaluates newly applied control state against stale pre-write telemetry or flashes between active, pending, and drift-attention states.
+
 ## [1.3.0] - 2026-07-12
 
 ### Changed

--- a/Casks/vifty.rb
+++ b/Casks/vifty.rb
@@ -1,5 +1,5 @@
 cask "vifty" do
-  version "1.3.0"
+  version "1.3.1"
   sha256 "92e803fa372c9cbd387b9b903ae0531031bc244804946d441616760f1d04a61f"
 
   url "https://github.com/Reedtrullz/Vifty/releases/download/v#{version}/Vifty-v#{version}.zip"

--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.3.0</string>
+	<string>1.3.1</string>
 	<key>CFBundleVersion</key>
-	<string>5</string>
+	<string>6</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>15.0</string>
 	<key>LSApplicationCategoryType</key>

--- a/Tests/ViftyCoreTests/DocumentationTrustSurfaceTests.swift
+++ b/Tests/ViftyCoreTests/DocumentationTrustSurfaceTests.swift
@@ -426,7 +426,7 @@ final class DocumentationTrustSurfaceTests: XCTestCase {
         let hotfixNotes = try read("docs/release-notes/v1.1.1.md")
         let unsignedDigestBoundary = "The unsigned-dev zip is valid only with its `.sha256` sidecar, and the SHA-256 digest in that sidecar must match the zip bytes."
 
-        XCTAssertTrue(cask.contains("version \"1.3.0\""))
+        XCTAssertTrue(cask.contains("version \"1.3.1\""))
         XCTAssertTrue(cask.contains("sha256 \"92e803fa372c9cbd387b9b903ae0531031bc244804946d441616760f1d04a61f\""))
         XCTAssertFalse(cask.contains("disable!"))
         XCTAssertTrue(readme.contains("Vifty `v1.3.0` is the current published Developer ID release."))
@@ -489,7 +489,9 @@ final class DocumentationTrustSurfaceTests: XCTestCase {
         XCTAssertTrue(releaseStatus.contains("Known issue: the published `v1.1.0` source/unsigned-dev release predates helper-install and app-polling hardening on `main`"))
         XCTAssertTrue(releaseStatus.contains("Do not retag `v1.1.0`, rebuild `Vifty-v1.1.0-unsigned-dev.zip` from later `main`, or claim the published `v1.1.0` convenience artifact is the official trusted binary."))
         XCTAssertTrue(releaseStatus.contains("The honest remediation is the `v1.1.1` source-first hotfix release"))
-        XCTAssertTrue(releaseStatus.contains("Release metadata in `Resources/Info.plist` and `Casks/vifty.rb` is aligned at `1.3.0`"))
+        XCTAssertTrue(releaseStatus.contains("Release-candidate metadata in `Resources/Info.plist` and `Casks/vifty.rb` is aligned at `1.3.1` build `6`"))
+        XCTAssertTrue(releaseStatus.contains("`v1.3.0` remains the latest trusted public artifact"))
+        XCTAssertTrue(releaseStatus.contains("pending the required post-release checksum handoff"))
         XCTAssertTrue(releaseStatus.contains("privacy-safe installed release-mode review both passed"))
         XCTAssertTrue(releaseStatus.contains("No explicit `v1.3.0` fan-control, Auto-restoration, or manual Fixed/Curve compatibility claim is made here."))
         XCTAssertTrue(releaseStatus.contains("At `v1.1.1` publication, `Resources/Info.plist` carried `1.1.1` while `Casks/vifty.rb` remained disabled on `1.1.0`"))

--- a/docs/release-status.md
+++ b/docs/release-status.md
@@ -6,6 +6,8 @@ This page is the current public trust status for Vifty releases. Update it whene
 
 As of 2026-07-12, `v1.3.0` is the current published Developer ID release. Its immutable tag resolves to `5cfd0eaf4409e3cfd2e57c766297d1609f8698cb`, source CI run `29209681445` passed, signed/notarized Release run `29209985030` passed, and the four canonical trust assets are public at the [v1.3.0 GitHub Release](https://github.com/Reedtrullz/Vifty/releases/tag/v1.3.0). `v1.1.1` remains the published source-first fallback; its immutable tag resolves to `a82f2237ff39c24a6b366dca8f95a17ee54fd972`.
 
+Release-candidate metadata in `Resources/Info.plist` and `Casks/vifty.rb` is aligned at `1.3.1` build `6` for the post-write fan-state confirmation fix. Until the tagged workflow publishes and independently verifies `Vifty-v1.3.1.zip`, `v1.3.0` remains the latest trusted public artifact and the checked-in cask checksum remains the prior published SHA-256 pending the required post-release checksum handoff.
+
 Developer ID publication evidence: the intended personal TeamID `X88J3853S2` is active, all required GitHub release secret names are configured, and both workflow and independent local verification accepted the signed public artifact's TeamID, Apple notarization ticket, stapling, LaunchDaemon allowlist, and Gatekeeper assessment. The exact public zip and cask now pass those checks independently. Do not use another organization's team or certificate for Vifty.
 
 The public `Vifty-v1.3.0.zip` and checked-in cask both resolve to SHA-256 `92e803fa372c9cbd387b9b903ae0531031bc244804946d441616760f1d04a61f`. The published artifact summary declares `status: "passed"`, uses schema ID `https://vifty.local/schemas/release-artifact-summary.schema.json`, and records that signature and notarization checks were not skipped. Developer ID readiness reports `status: "ready"` with release source ref, source CI, Release workflow, secret names, and all four public assets passed.
@@ -24,7 +26,7 @@ Auto-update status: unavailable in `v1.3.0`, source-first, and unsigned-dev buil
 
 Public release facts:
 
-- Release metadata in `Resources/Info.plist` and `Casks/vifty.rb` is aligned at `1.3.0`, and the checked-in cask checksum matches the immutable public artifact.
+- Release-candidate metadata in `Resources/Info.plist` and `Casks/vifty.rb` is aligned at `1.3.1` build `6`; `v1.3.0` remains the latest trusted public artifact pending the tagged release and checksum handoff.
 - Source CI run `29209681445` passed on release commit `5cfd0eaf4409e3cfd2e57c766297d1609f8698cb`, and Release run `29209985030` passed all signing, notarization, pre-publication verification, checklist, and publication steps.
 - The GitHub Release publishes `Vifty-v1.3.0.zip`, `Vifty-v1.3.0.zip.sha256`, `Vifty-v1.3.0-artifact-summary.json`, and `Vifty-v1.3.0-release-checklist.md`.
 - The published workflow summary and an independent downloaded-artifact verification both passed with TeamID `X88J3853S2`, no signature skips, and no notarization skips.


### PR DESCRIPTION
## Summary
- bump the app to v1.3.1 build 6
- document the post-write fan-state confirmation fix
- preserve v1.3.0 as the latest trusted public artifact until the tagged workflow and checksum handoff complete

## Verification
- `scripts/validate-release-metadata.sh --mode developer-id`
- `swift test --build-path "$PWD/.build" --filter DocumentationTrustSurfaceTests` (33 passed)
- `swift test --build-path "$PWD/.build" --filter ReleaseMetadataScriptTests` (77 passed)
- `make verify SWIFT_BUILD_PATH="$PWD/.build"` (712 tests passed plus warnings-as-errors and release bundle checks)
- `git diff --check`

## Release boundary
The cask version points at the candidate while retaining the prior published checksum. The checksum must be updated only from the signed/notarized v1.3.1 workflow output after publication.
