### PR TITLE
fix: preempt stale fan writes on Auto

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.2] - 2026-07-13
+
+### Fixed
+- Preempt in-flight Fixed or Curve writes when Auto is selected so a suspended fan write cannot resume and reclaim hardware control after Auto appears active.
+- Allow recent manual target writes a short telemetry-settling window before showing drift attention, while preserving alerts for sustained target mismatch.
+
 ## [1.3.1] - 2026-07-13
 
 ### Fixed

--- a/Casks/vifty.rb
+++ b/Casks/vifty.rb
@@ -1,5 +1,5 @@
 cask "vifty" do
-  version "1.3.1"
+  version "1.3.2"
   sha256 "a2a701d67febd8c533470df2d420144560b3c9dcef627fd82b99b2454cb0e417"
 
   url "https://github.com/Reedtrullz/Vifty/releases/download/v#{version}/Vifty-v#{version}.zip"

--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.3.1</string>
+	<string>1.3.2</string>
 	<key>CFBundleVersion</key>
-	<string>6</string>
+	<string>7</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>15.0</string>
 	<key>LSApplicationCategoryType</key>

--- a/Sources/Vifty/AppModel.swift
+++ b/Sources/Vifty/AppModel.swift
@@ -264,6 +264,7 @@ final class AppModel: ObservableObject {
     static let notificationAgentCoolingAttentionDefaultsKey = AppPreferencesStore.legacyNotificationAgentCoolingAttentionDefaultsKey
     static let manualTargetDriftRPMThreshold = 75
     static let manualTargetDriftAttentionSampleCount = 2
+    static let manualTargetWriteSettleInterval: TimeInterval = 5
     static let manualResponseRPMGapThreshold = 250
     static let defaultCodexUsageRefreshInterval: TimeInterval = 5 * 60
 
@@ -287,6 +288,7 @@ final class AppModel: ObservableObject {
     private var startupModeApplied = false
     private var notificationTransitionState = LocalNotificationTransitionState()
     private var manualTargetDriftSampleCounts: [Int: Int] = [:]
+    private var manualTargetSettlingFanIDs: Set<Int> = []
     private var elevatedThermalPressureStartedAt: Date?
     private var lastCodexUsageRefreshAt: Date?
     private var lastPowerTelemetryRefreshAt: Date?
@@ -2145,7 +2147,8 @@ final class AppModel: ObservableObject {
         }
 
         return fans.filter { fan in
-            guard fan.hardwareMode == .forced,
+            guard !manualTargetSettlingFanIDs.contains(fan.id),
+                  fan.hardwareMode == .forced,
                   let targetRPM = fan.targetRPM,
                   let expectedRPM = expectedManualTargetRPM(for: fan) else {
                 return false
@@ -2594,6 +2597,10 @@ final class AppModel: ObservableObject {
 
     private func syncState() async {
         assignIfChanged(\.controlState, await coordinator.state)
+        manualTargetSettlingFanIDs = await coordinator.recentManualWriteFanIDs(
+            at: now(),
+            within: Self.manualTargetWriteSettleInterval
+        )
         updateManualTargetDriftStability()
     }
 

--- a/Sources/ViftyCore/HardwareService.swift
+++ b/Sources/ViftyCore/HardwareService.swift
@@ -20,6 +20,7 @@ public actor FanControlCoordinator {
     private var fanOverrides: [FanCurveOverride] = []
     private var fixedFanTargets: [Int: Int] = [:]
     private var lastManualWriteAtByFanID: [Int: Date] = [:]
+    private var modeGeneration: UInt64 = 0
 
     public private(set) var state: ControlState
     public private(set) var lastObservedSnapshot: HardwareSnapshot?
@@ -52,6 +53,7 @@ public actor FanControlCoordinator {
     }
 
     public func setMode(_ mode: FanMode) {
+        modeGeneration &+= 1
         state.mode = mode
         switch mode {
         case .auto:
@@ -75,72 +77,101 @@ public actor FanControlCoordinator {
     }
 
     public func tick() async throws -> HardwareSnapshot {
-        lastObservedSnapshot = nil
-        let snapshot = try await hardware.snapshot()
-        lastObservedSnapshot = snapshot
-        if state.mode != .auto, snapshot.temperatureSensors.isEmpty {
-            try await restoreAuto(for: snapshot.fans)
-            autoRestoreRequested = false
-            state.manualControlActive = false
-            state.lastAppliedRPM = [:]
-            lastManualWriteAtByFanID = [:]
-            state.statusMessage = "Sensor unavailable, restored Auto"
-            uncleanMarker.clear()
-            throw ViftyError.noTemperatureSensors
-        }
-        try validate(snapshot)
-
-        let wroteFanState: Bool
-        switch state.mode {
-        case .auto:
-            wroteFanState = state.manualControlActive || autoRestoreRequested
-            if wroteFanState {
-                try await restoreAuto(for: snapshot.fans)
+        while true {
+            let generation = modeGeneration
+            let mode = state.mode
+            lastObservedSnapshot = nil
+            let snapshot = try await hardware.snapshot()
+            guard generation == modeGeneration else { continue }
+            lastObservedSnapshot = snapshot
+            if mode != .auto, snapshot.temperatureSensors.isEmpty {
+                guard try await restoreAuto(for: snapshot.fans, generation: generation) else { continue }
+                autoRestoreRequested = false
+                state.manualControlActive = false
+                state.lastAppliedRPM = [:]
+                lastManualWriteAtByFanID = [:]
+                state.statusMessage = "Sensor unavailable, restored Auto"
+                uncleanMarker.clear()
+                throw ViftyError.noTemperatureSensors
             }
-            autoRestoreRequested = false
-            state.manualControlActive = false
-            state.lastAppliedRPM = [:]
-            lastManualWriteAtByFanID = [:]
-            state.statusMessage = "Auto"
-            uncleanMarker.clear()
-        case .fixedRPM(let rpm):
-            wroteFanState = try await applyFixedRPM(rpm, snapshot: snapshot)
-            state.manualControlActive = true
-            uncleanMarker.markActive()
-        case .temperatureCurve(let curve):
-            if fanOverrides.isEmpty {
-                wroteFanState = try await applyCurve(curve, snapshot: snapshot)
-            } else {
-                wroteFanState = try await applyCurveWithOverrides(curve, fanOverrides: fanOverrides, snapshot: snapshot)
+            try validate(snapshot, mode: mode)
+
+            let wroteFanState: Bool
+            switch mode {
+            case .auto:
+                wroteFanState = state.manualControlActive || autoRestoreRequested
+                if wroteFanState {
+                    guard try await restoreAuto(for: snapshot.fans, generation: generation) else { continue }
+                }
+                guard generation == modeGeneration else { continue }
+                autoRestoreRequested = false
+                state.manualControlActive = false
+                state.lastAppliedRPM = [:]
+                lastManualWriteAtByFanID = [:]
+                state.statusMessage = "Auto"
+                uncleanMarker.clear()
+            case .fixedRPM(let rpm):
+                guard let applied = try await applyFixedRPM(rpm, snapshot: snapshot, generation: generation) else { continue }
+                wroteFanState = applied
+                guard generation == modeGeneration else { continue }
+                state.manualControlActive = true
+                uncleanMarker.markActive()
+            case .temperatureCurve(let curve):
+                let applied: Bool?
+                if fanOverrides.isEmpty {
+                    applied = try await applyCurve(curve, snapshot: snapshot, generation: generation)
+                } else {
+                    applied = try await applyCurveWithOverrides(
+                        curve,
+                        fanOverrides: fanOverrides,
+                        snapshot: snapshot,
+                        generation: generation
+                    )
+                }
+                guard let applied else { continue }
+                wroteFanState = applied
+                guard generation == modeGeneration else { continue }
+                state.manualControlActive = true
+                uncleanMarker.markActive()
             }
-            state.manualControlActive = true
-            uncleanMarker.markActive()
-        }
 
-        guard wroteFanState else { return snapshot }
+            guard generation == modeGeneration else { continue }
+            guard wroteFanState else { return snapshot }
 
-        let confirmedSnapshot = try await hardware.snapshot()
-        lastObservedSnapshot = confirmedSnapshot
-        if state.mode != .auto, confirmedSnapshot.temperatureSensors.isEmpty {
-            try await restoreAuto(for: confirmedSnapshot.fans)
-            autoRestoreRequested = false
-            state.manualControlActive = false
-            state.lastAppliedRPM = [:]
-            lastManualWriteAtByFanID = [:]
-            state.statusMessage = "Sensor unavailable, restored Auto"
-            uncleanMarker.clear()
-            throw ViftyError.noTemperatureSensors
+            let confirmedSnapshot = try await hardware.snapshot()
+            guard generation == modeGeneration else { continue }
+            lastObservedSnapshot = confirmedSnapshot
+            if mode != .auto, confirmedSnapshot.temperatureSensors.isEmpty {
+                guard try await restoreAuto(for: confirmedSnapshot.fans, generation: generation) else { continue }
+                autoRestoreRequested = false
+                state.manualControlActive = false
+                state.lastAppliedRPM = [:]
+                lastManualWriteAtByFanID = [:]
+                state.statusMessage = "Sensor unavailable, restored Auto"
+                uncleanMarker.clear()
+                throw ViftyError.noTemperatureSensors
+            }
+            try validate(confirmedSnapshot, mode: mode)
+            return confirmedSnapshot
         }
-        try validate(confirmedSnapshot)
-        return confirmedSnapshot
     }
 
     public func forceAuto() async -> AutoRestoreResult {
+        let previousState = state
+        let previousAutoRestoreRequested = autoRestoreRequested
+        modeGeneration &+= 1
+        let generation = modeGeneration
+        state.mode = .auto
+        autoRestoreRequested = true
+        uncleanMarker.markActive()
         do {
             let snapshot = try await hardware.snapshot()
-            try await restoreAuto(for: snapshot.fans)
+            guard generation == modeGeneration,
+                  try await restoreAuto(for: snapshot.fans, generation: generation),
+                  generation == modeGeneration else {
+                return .failed(message: "Auto restore was superseded by a newer fan-control request")
+            }
             autoRestoreRequested = false
-            state.mode = .auto
             state.manualControlActive = false
             state.lastAppliedRPM = [:]
             lastManualWriteAtByFanID = [:]
@@ -149,29 +180,43 @@ public actor FanControlCoordinator {
             return .restored
         } catch {
             let message = error.localizedDescription
-            state.statusMessage = "Auto restore failed: \(message)"
+            if generation == modeGeneration {
+                state = previousState
+                state.statusMessage = "Auto restore failed: \(message)"
+                autoRestoreRequested = previousAutoRestoreRequested
+            }
             return .failed(message: message)
         }
     }
 
-    private func validate(_ snapshot: HardwareSnapshot) throws {
+    public func recentManualWriteFanIDs(at date: Date, within interval: TimeInterval) -> Set<Int> {
+        guard state.mode != .auto, interval > 0 else { return [] }
+        return Set(lastManualWriteAtByFanID.compactMap { fanID, writtenAt in
+            let age = date.timeIntervalSince(writtenAt)
+            return age >= 0 && age < interval ? fanID : nil
+        })
+    }
+
+    private func validate(_ snapshot: HardwareSnapshot, mode: FanMode? = nil) throws {
         guard snapshot.isAppleSilicon, snapshot.isMacBookPro else {
             throw ViftyError.unsupportedHardware(snapshot.modelIdentifier)
         }
         guard !snapshot.temperatureSensors.isEmpty else {
             throw ViftyError.noTemperatureSensors
         }
-        if state.mode != .auto, !snapshot.fans.contains(where: \.controllable) {
+        if (mode ?? state.mode) != .auto, !snapshot.fans.contains(where: \.controllable) {
             throw ViftyError.noControllableFans
         }
     }
 
-    private func applyFixedRPM(_ rpm: Int, snapshot: HardwareSnapshot) async throws -> Bool {
+    private func applyFixedRPM(_ rpm: Int, snapshot: HardwareSnapshot, generation: UInt64) async throws -> Bool? {
         var appliedFanState = false
         for fan in snapshot.fans where fan.controllable {
+            guard generation == modeGeneration else { return nil }
             let target = FanCurve.clamp(fixedFanTargets[fan.id] ?? rpm, fan.minimumRPM, fan.maximumRPM)
             guard shouldApply(target, to: fan, capturedAt: snapshot.capturedAt) else { continue }
             try await hardware.apply(FanCommand(fanID: fan.id, mode: .fixedRPM(target)), fan: fan)
+            guard generation == modeGeneration else { return nil }
             appliedFanState = true
             state.lastAppliedRPM[fan.id] = target
             lastManualWriteAtByFanID[fan.id] = snapshot.capturedAt
@@ -180,7 +225,7 @@ public actor FanControlCoordinator {
         return appliedFanState
     }
 
-    private func applyCurve(_ curve: FanCurve, snapshot: HardwareSnapshot) async throws -> Bool {
+    private func applyCurve(_ curve: FanCurve, snapshot: HardwareSnapshot, generation: UInt64) async throws -> Bool? {
         let sensor = selectedSensor(for: curve, snapshot: snapshot)
         guard let sensor else {
             try await restoreAuto(for: snapshot.fans)
@@ -189,6 +234,7 @@ public actor FanControlCoordinator {
 
         var appliedFanState = false
         for fan in snapshot.fans where fan.controllable {
+            guard generation == modeGeneration else { return nil }
             let target = curve.targetRPM(
                 for: sensor.celsius,
                 minimumRPM: fan.minimumRPM,
@@ -196,6 +242,7 @@ public actor FanControlCoordinator {
             )
             guard shouldApply(target, to: fan, capturedAt: snapshot.capturedAt) else { continue }
             try await hardware.apply(FanCommand(fanID: fan.id, mode: .fixedRPM(target)), fan: fan)
+            guard generation == modeGeneration else { return nil }
             appliedFanState = true
             state.lastAppliedRPM[fan.id] = target
             lastManualWriteAtByFanID[fan.id] = snapshot.capturedAt
@@ -245,14 +292,32 @@ public actor FanControlCoordinator {
         return capturedAt.timeIntervalSince(lastWriteAt) >= manualReassertionInterval
     }
 
-    private func restoreAuto(for fans: [Fan]) async throws {
+    @discardableResult
+    private func restoreAuto(for fans: [Fan], generation: UInt64? = nil) async throws -> Bool {
         for fan in fans where fan.controllable {
+            if let generation, generation != modeGeneration { return false }
             try await hardware.restoreAuto(fan: fan)
+            if let generation, generation != modeGeneration { return false }
         }
+        return true
     }
 
     @discardableResult
     public func applyCurveWithOverrides(_ curve: FanCurve, fanOverrides: [FanCurveOverride], snapshot: HardwareSnapshot) async throws -> Bool {
+        try await applyCurveWithOverrides(
+            curve,
+            fanOverrides: fanOverrides,
+            snapshot: snapshot,
+            generation: nil
+        ) ?? false
+    }
+
+    private func applyCurveWithOverrides(
+        _ curve: FanCurve,
+        fanOverrides: [FanCurveOverride],
+        snapshot: HardwareSnapshot,
+        generation: UInt64?
+    ) async throws -> Bool? {
         let sensor = selectedSensor(for: curve, snapshot: snapshot)
         guard let sensor else {
             try await restoreAuto(for: snapshot.fans)
@@ -263,6 +328,7 @@ public actor FanControlCoordinator {
 
         var appliedFanState = false
         for fan in snapshot.fans where fan.controllable {
+            if let generation, generation != modeGeneration { return nil }
             let target: Int
             if let override = overridesByID[fan.id],
                let fanCurve = curve.applying(override: override) {
@@ -280,6 +346,7 @@ public actor FanControlCoordinator {
             }
             guard shouldApply(target, to: fan, capturedAt: snapshot.capturedAt) else { continue }
             try await hardware.apply(FanCommand(fanID: fan.id, mode: .fixedRPM(target)), fan: fan)
+            if let generation, generation != modeGeneration { return nil }
             appliedFanState = true
             state.lastAppliedRPM[fan.id] = target
             lastManualWriteAtByFanID[fan.id] = snapshot.capturedAt

--- a/Tests/ViftyCoreTests/AppModelTests.swift
+++ b/Tests/ViftyCoreTests/AppModelTests.swift
@@ -1252,7 +1252,7 @@ final class AppModelTests: XCTestCase {
         XCTAssertTrue(model.controlOwnershipNeedsAttention)
     }
 
-    func testControlOwnershipSuppressesSingleSampleManualTargetDriftDuringReassertion() async {
+    func testControlOwnershipSuppressesTargetDriftDuringRecentManualWriteSettling() async {
         func snapshot(targetRPM: Int) -> HardwareSnapshot {
             HardwareSnapshot(
                 fans: [
@@ -1302,14 +1302,69 @@ final class AppModelTests: XCTestCase {
 
         await model.pollOnce()
 
-        XCTAssertEqual(model.controlOwnershipSummary, "Hardware fan target drift detected; Vifty will reassert · F0")
-        XCTAssertTrue(model.controlOwnershipNeedsAttention)
+        XCTAssertEqual(model.controlOwnershipSummary, "Vifty Fixed owns fan targets · 3600 RPM · until changed; reasserts if macOS drifts")
+        XCTAssertFalse(model.controlOwnershipNeedsAttention)
 
         await hardware.setSnapshot(snapshot(targetRPM: 3600))
         await model.pollOnce()
 
         XCTAssertEqual(model.controlOwnershipSummary, "Vifty Fixed owns fan targets · 3600 RPM · until changed; reasserts if macOS drifts")
         XCTAssertFalse(model.controlOwnershipNeedsAttention)
+    }
+
+    func testControlOwnershipSettlesDelayedTargetReadbackAfterManualWriteThenWarns() async {
+        let startedAt = Date(timeIntervalSince1970: 1_750_000_000)
+        let clock = AppModelTestClock(now: startedAt)
+        let staleSnapshot = HardwareSnapshot(
+            fans: [
+                Fan(
+                    id: 0,
+                    name: "Left",
+                    currentRPM: 2200,
+                    minimumRPM: 1400,
+                    maximumRPM: 6000,
+                    controllable: true,
+                    hardwareMode: .forced,
+                    targetRPM: 2200
+                )
+            ],
+            temperatureSensors: [
+                TemperatureSensor(id: "Tp09", name: "CPU Proximity", celsius: 78, source: .smc)
+            ],
+            modelIdentifier: "MacBookPro18,3",
+            isAppleSilicon: true,
+            isMacBookPro: true,
+            capturedAt: startedAt
+        )
+        let hardware = AppModelFakeHardware(snapshot: staleSnapshot)
+        let coordinator = FanControlCoordinator(
+            hardware: hardware,
+            uncleanMarker: ManualControlMarker(url: temporaryMarkerPath()),
+            manualReassertionInterval: 30
+        )
+        await coordinator.setMode(.fixedRPM(3600))
+        let model = AppModel(
+            coordinator: coordinator,
+            powerReader: { PowerSnapshot(percent: 50) },
+            thermalReader: { .nominal },
+            now: { clock.now },
+            daemonPing: { true },
+            agentStatusReader: { nil }
+        )
+        model.daemonReachable = true
+        model.daemonResponding = true
+
+        await model.pollOnce()
+        XCTAssertEqual(model.controlOwnershipSummary, "Vifty Fixed owns fan targets · 3600 RPM · until changed; reasserts if macOS drifts")
+        XCTAssertFalse(model.controlOwnershipNeedsAttention)
+
+        clock.now = startedAt.addingTimeInterval(AppModel.manualTargetWriteSettleInterval + 0.1)
+        await model.pollOnce()
+        XCTAssertFalse(model.controlOwnershipNeedsAttention)
+        await model.pollOnce()
+
+        XCTAssertEqual(model.controlOwnershipSummary, "Hardware fan target drift detected; Vifty will reassert · F0")
+        XCTAssertTrue(model.controlOwnershipNeedsAttention)
     }
 
     func testControlOwnershipWarnsWhenHotManualResponseCannotBeConfirmed() {

--- a/Tests/ViftyCoreTests/DocumentationTrustSurfaceTests.swift
+++ b/Tests/ViftyCoreTests/DocumentationTrustSurfaceTests.swift
@@ -426,7 +426,7 @@ final class DocumentationTrustSurfaceTests: XCTestCase {
         let hotfixNotes = try read("docs/release-notes/v1.1.1.md")
         let unsignedDigestBoundary = "The unsigned-dev zip is valid only with its `.sha256` sidecar, and the SHA-256 digest in that sidecar must match the zip bytes."
 
-        XCTAssertTrue(cask.contains("version \"1.3.1\""))
+        XCTAssertTrue(cask.contains("version \"1.3.2\""))
         XCTAssertTrue(cask.contains("sha256 \"a2a701d67febd8c533470df2d420144560b3c9dcef627fd82b99b2454cb0e417\""))
         XCTAssertFalse(cask.contains("disable!"))
         XCTAssertTrue(readme.contains("Vifty `v1.3.1` is the current published Developer ID release."))
@@ -489,9 +489,11 @@ final class DocumentationTrustSurfaceTests: XCTestCase {
         XCTAssertTrue(releaseStatus.contains("Known issue: the published `v1.1.0` source/unsigned-dev release predates helper-install and app-polling hardening on `main`"))
         XCTAssertTrue(releaseStatus.contains("Do not retag `v1.1.0`, rebuild `Vifty-v1.1.0-unsigned-dev.zip` from later `main`, or claim the published `v1.1.0` convenience artifact is the official trusted binary."))
         XCTAssertTrue(releaseStatus.contains("The honest remediation is the `v1.1.1` source-first hotfix release"))
-        XCTAssertTrue(releaseStatus.contains("Release metadata in `Resources/Info.plist` and `Casks/vifty.rb` is aligned at `1.3.1` build `6`"))
+        XCTAssertTrue(releaseStatus.contains("Release-candidate metadata in `Resources/Info.plist` and `Casks/vifty.rb` is aligned at `1.3.2` build `7`"))
+        XCTAssertTrue(releaseStatus.contains("The supervised `v1.3.1` manual smoke is not a passed compatibility claim."))
+        XCTAssertTrue(releaseStatus.contains("selecting Auto during an in-flight Curve tick could briefly show Auto active before the suspended write resumed"))
         XCTAssertTrue(releaseStatus.contains("The privacy-safe release bundle at `.build/public-release-v1.3.0/installed-release-evidence-public-safe` passed"))
-        XCTAssertTrue(releaseStatus.contains("No installed release-mode, signed-helper parity, Auto-restoration, or manual Fixed/Curve compatibility claim is made for `v1.3.1`"))
+        XCTAssertTrue(releaseStatus.contains("no installed Auto-restoration or manual Fixed/Curve compatibility claim is made for `v1.3.1`"))
         XCTAssertTrue(releaseStatus.contains("At `v1.1.1` publication, `Resources/Info.plist` carried `1.1.1` while `Casks/vifty.rb` remained disabled on `1.1.0`"))
         XCTAssertTrue(releaseStatus.contains("Do not update the Homebrew cask checksum for a source-first release, do not re-enable the cask, and do not point Homebrew at unsigned-dev artifacts."))
         XCTAssertTrue(releaseStatus.contains("## Source-First v1.1.1 Operator Checks"))

--- a/Tests/ViftyCoreTests/FanControlCoordinatorTests.swift
+++ b/Tests/ViftyCoreTests/FanControlCoordinatorTests.swift
@@ -286,6 +286,44 @@ final class FanControlCoordinatorTests: XCTestCase {
         XCTAssertFalse(state.manualControlActive)
     }
 
+    func testAutoSelectionPreemptsInFlightCurveWritesAndRestoresBothFans() async throws {
+        let curve = FanCurve(points: [
+            CurvePoint(temperatureCelsius: 50, rpm: 3_000),
+            CurvePoint(temperatureCelsius: 70, rpm: 5_000)
+        ])
+        let hardware = FakeHardware(
+            snapshot: HardwareSnapshot(
+                fans: [
+                    Fan(id: 0, name: "Left Fan", currentRPM: 1_500, minimumRPM: 1_400, maximumRPM: 6_000, controllable: true, hardwareMode: .automatic, targetRPM: 1_500),
+                    Fan(id: 1, name: "Right Fan", currentRPM: 1_600, minimumRPM: 1_500, maximumRPM: 6_200, controllable: true, hardwareMode: .automatic, targetRPM: 1_600)
+                ],
+                temperatureSensors: [Self.sensor(60)],
+                modelIdentifier: "MacBookPro18,1",
+                isAppleSilicon: true,
+                isMacBookPro: true
+            ),
+            reflectsCommandsInSnapshot: true
+        )
+        await hardware.pauseFirstApply()
+        let coordinator = FanControlCoordinator(hardware: hardware, uncleanMarker: Self.marker())
+        await coordinator.setMode(.temperatureCurve(curve))
+
+        let tickTask = Task { try await coordinator.tick() }
+        await hardware.waitForPausedApply()
+        await coordinator.setMode(.auto)
+        await hardware.resumePausedApply()
+        let snapshot = try await tickTask.value
+        let appliedCommandCount = await hardware.appliedCommands.count
+        let restoredFanIDs = await hardware.restoredFanIDs
+
+        XCTAssertEqual(appliedCommandCount, 1)
+        XCTAssertEqual(restoredFanIDs, [0, 1])
+        XCTAssertEqual(snapshot.fans.map(\.hardwareMode), [.automatic, .automatic])
+        let state = await coordinator.state
+        XCTAssertEqual(state.mode, .auto)
+        XCTAssertFalse(state.manualControlActive)
+    }
+
     func testExplicitAutoSelectionRestoresEvenWhenStateWasAlreadyCleared() async throws {
         let marker = Self.marker()
         let hardware = FakeHardware(
@@ -556,6 +594,10 @@ private actor FakeHardware: HardwareService {
     var restoredFanIDs: [Int] = []
     var restoreError: Error?
     let reflectsCommandsInSnapshot: Bool
+    private var shouldPauseFirstApply = false
+    private var applyIsPaused = false
+    private var pausedApplyWaiters: [CheckedContinuation<Void, Never>] = []
+    private var applyResumeContinuation: CheckedContinuation<Void, Never>?
 
     init(snapshot: HardwareSnapshot, reflectsCommandsInSnapshot: Bool = false) {
         self.snapshotValue = snapshot
@@ -578,8 +620,34 @@ private actor FakeHardware: HardwareService {
         restoreError = error
     }
 
+    func pauseFirstApply() {
+        shouldPauseFirstApply = true
+    }
+
+    func waitForPausedApply() async {
+        guard !applyIsPaused else { return }
+        await withCheckedContinuation { continuation in
+            pausedApplyWaiters.append(continuation)
+        }
+    }
+
+    func resumePausedApply() {
+        applyResumeContinuation?.resume()
+        applyResumeContinuation = nil
+    }
+
     func apply(_ command: FanCommand, fan: Fan) async throws {
         appliedCommands.append(command)
+        if shouldPauseFirstApply {
+            shouldPauseFirstApply = false
+            applyIsPaused = true
+            pausedApplyWaiters.forEach { $0.resume() }
+            pausedApplyWaiters.removeAll()
+            await withCheckedContinuation { continuation in
+                applyResumeContinuation = continuation
+            }
+            applyIsPaused = false
+        }
         guard reflectsCommandsInSnapshot,
               case .fixedRPM(let targetRPM) = command.mode,
               let fanIndex = snapshotValue.fans.firstIndex(where: { $0.id == fan.id }) else {

--- a/docs/release-status.md
+++ b/docs/release-status.md
@@ -6,6 +6,10 @@ This page is the current public trust status for Vifty releases. Update it whene
 
 As of 2026-07-13, `v1.3.1` is the current published Developer ID release. Its immutable tag resolves to `be79fca52668ae906ac310eab6dd0b0689afda3c`, source CI run `29214928452` passed, signed/notarized Release run `29215235660` passed, and the four canonical trust assets are public at the [v1.3.1 GitHub Release](https://github.com/Reedtrullz/Vifty/releases/tag/v1.3.1). `v1.1.1` remains the published source-first fallback; its immutable tag resolves to `a82f2237ff39c24a6b366dca8f95a17ee54fd972`.
 
+Release-candidate metadata in `Resources/Info.plist` and `Casks/vifty.rb` is aligned at `1.3.2` build `7` for in-flight manual-write preemption and delayed target-readback settling. Until the tagged workflow publishes and independently verifies `Vifty-v1.3.2.zip`, `v1.3.1` remains the latest trusted public artifact and the checked-in cask checksum remains its published SHA-256 pending the required post-release checksum handoff.
+
+The supervised `v1.3.1` manual smoke is not a passed compatibility claim. Fixed and Curve control reached their targets and the right-fan curve line rendered, but selecting Auto during an in-flight Curve tick could briefly show Auto active before the suspended write resumed and returned both fans to Forced mode. Operator recovery after quitting Vifty restored and read-only diagnostics confirmed hardware Auto. `v1.3.2` must repeat exact-build helper parity, installed release-mode review, and supervised Fixed/Curve/Auto smoke before compatibility evidence is promoted.
+
 Developer ID publication evidence: the intended personal TeamID `X88J3853S2` is active, all required GitHub release secret names are configured, and both workflow and independent local verification accepted the signed public artifact's TeamID, Apple notarization ticket, stapling, LaunchDaemon allowlist, and Gatekeeper assessment. The exact public zip and cask now pass those checks independently. Do not use another organization's team or certificate for Vifty.
 
 The public `Vifty-v1.3.1.zip` and checked-in cask both resolve to SHA-256 `a2a701d67febd8c533470df2d420144560b3c9dcef627fd82b99b2454cb0e417`. The published artifact summary declares `status: "passed"`, uses schema ID `https://vifty.local/schemas/release-artifact-summary.schema.json`, and records that signature and notarization checks were not skipped. Independent artifact verification and Developer ID readiness both passed with the exact source ref, source CI, Release workflow, secret names, and all four public assets.
@@ -24,12 +28,12 @@ Auto-update status: unavailable in `v1.3.1`, source-first, and unsigned-dev buil
 
 Public release facts:
 
-- Release metadata in `Resources/Info.plist` and `Casks/vifty.rb` is aligned at `1.3.1` build `6`, and the checked-in cask checksum matches the immutable public artifact.
+- Release-candidate metadata in `Resources/Info.plist` and `Casks/vifty.rb` is aligned at `1.3.2` build `7`; `v1.3.1` remains the latest trusted public artifact pending the tagged release and checksum handoff.
 - Source CI run `29214928452` passed on release commit `be79fca52668ae906ac310eab6dd0b0689afda3c`, and Release run `29215235660` passed all signing, notarization, pre-publication verification, checklist, and publication steps.
 - The GitHub Release publishes `Vifty-v1.3.1.zip`, `Vifty-v1.3.1.zip.sha256`, `Vifty-v1.3.1-artifact-summary.json`, and `Vifty-v1.3.1-release-checklist.md`.
 - The published workflow summary and an independent downloaded-artifact verification both passed with TeamID `X88J3853S2`, no signature skips, and no notarization skips.
 - `scripts/check-release-readiness.sh --mode developer-id --version 1.3.1 --repo Reedtrullz/Vifty --require-source-ref be79fca52668ae906ac310eab6dd0b0689afda3c --json` reported `ready` before the cask follow-up moved `main`.
-- Independent verification of the downloaded public `v1.3.1` artifact passed. No installed release-mode, signed-helper parity, Auto-restoration, or manual Fixed/Curve compatibility claim is made for `v1.3.1` until exact-build evidence is reviewed.
+- Independent verification of the downloaded public `v1.3.1` artifact passed. Its supervised manual smoke exposed the in-flight Auto/Curve race described above, so no installed Auto-restoration or manual Fixed/Curve compatibility claim is made for `v1.3.1`.
 - `scripts/check-release-secrets.sh --repo Reedtrullz/Vifty` reports every required secret name. It does not read or print secret values.
 - Earlier local TeamID, hardened-runtime, notarization, stapling, LaunchDaemon allowlist, and Gatekeeper smoke checks passed for a locally built candidate. The published GitHub Release artifact has now repeated those checks independently; the local smoke remains corroborating preflight, not public artifact proof.
 


### PR DESCRIPTION
## Summary
- preempt superseded Fixed/Curve work at every actor suspension before it can write another fan or commit stale state
- make forced Auto restore generation-aware while preserving prior manual intent when hardware restore fails
- suppress target-drift attention only during a five-second post-write telemetry settling window
- prepare immutable v1.3.2 build 7 metadata and document the failed v1.3.1 manual-smoke non-claim

## Evidence
- user screen recording reproduced Curve-to-Auto returning to Forced mode after Auto appeared active
- regression: `testAutoSelectionPreemptsInFlightCurveWritesAndRestoresBothFans`
- drift-settling tests preserve sustained mismatch escalation
- `scripts/validate-release-metadata.sh`
- `make verify-full`

## Safety
- operator recovery quit Vifty, restored Auto, and read-only diagnose confirmed both fans Auto before implementation work
- no automated UI fan-control actions were used
- v1.3.1 remains immutable; v1.3.2 must repeat exact-build helper parity and supervised Fixed/Curve/Auto smoke before compatibility claims
