### PR TITLE
chore: bootstrap release manifest history checker

### DIFF
--- a/scripts/check-release-manifest-history-from-git.sh
+++ b/scripts/check-release-manifest-history-from-git.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="${VIFTY_RELEASE_MANIFEST_ROOT:-$(cd "${SCRIPT_DIR}/.." && pwd)}"
+SOURCE_REPOSITORY="${VIFTY_RELEASE_SOURCE_REPOSITORY_ROOT:-${ROOT_DIR}}"
+CURRENT_MANIFEST="${ROOT_DIR}/.github/release-manifest.json"
+BASE_REF=""
+
+usage() {
+  cat >&2 <<'USAGE'
+Usage: scripts/check-release-manifest-history-from-git.sh --base-ref <trusted-git-object>
+
+Materializes the continuity checker and any prior release manifest from the
+trusted base Git object before enforcing append-only release history. A missing
+base manifest is accepted only when that already-trusted checker recognizes the
+exact pinned v1.3.2 introduction boundary.
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --base-ref)
+      [[ $# -ge 2 ]] || { echo "error: --base-ref requires a value" >&2; exit 64; }
+      BASE_REF="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "error: unknown argument: $1" >&2
+      usage
+      exit 64
+      ;;
+  esac
+done
+
+[[ -n "${BASE_REF}" ]] || { echo "error: --base-ref is required" >&2; exit 64; }
+[[ -f "${CURRENT_MANIFEST}" ]] || { echo "error: current release manifest not found: ${CURRENT_MANIFEST}" >&2; exit 66; }
+
+if ! BASE_COMMIT="$(git -C "${SOURCE_REPOSITORY}" rev-parse --verify "${BASE_REF}^{commit}" 2>/dev/null)"; then
+  echo "error: trusted release-manifest base ref is unavailable: ${BASE_REF}" >&2
+  exit 65
+fi
+
+scratch="$(mktemp -d "${TMPDIR:-/tmp}/vifty-release-manifest-history.XXXXXX")"
+cleanup() {
+  rm -rf "${scratch}"
+}
+trap cleanup EXIT
+
+base_manifest="${scratch}/base-release-manifest.json"
+trusted_checker="${scratch}/check-release-manifest-history.rb"
+
+if ! git -C "${SOURCE_REPOSITORY}" show "${BASE_COMMIT}:scripts/check-release-manifest-history.rb" > "${trusted_checker}" 2>/dev/null; then
+  echo "error: trusted base ${BASE_COMMIT} has no release-manifest continuity checker; land the pinned checker before introducing the manifest" >&2
+  exit 65
+fi
+
+if git -C "${SOURCE_REPOSITORY}" cat-file -e "${BASE_COMMIT}:.github/release-manifest.json" 2>/dev/null; then
+  if ! git -C "${SOURCE_REPOSITORY}" show "${BASE_COMMIT}:.github/release-manifest.json" > "${base_manifest}"; then
+    echo "error: could not materialize trusted base release manifest from ${BASE_COMMIT}" >&2
+    exit 65
+  fi
+  ruby "${trusted_checker}" --current "${CURRENT_MANIFEST}" --base "${base_manifest}"
+else
+  ruby "${trusted_checker}" \
+    --current "${CURRENT_MANIFEST}" \
+    --allow-initial-v1.3.2
+fi

--- a/scripts/check-release-manifest-history.rb
+++ b/scripts/check-release-manifest-history.rb
@@ -63,6 +63,13 @@ base = read_manifest(options.fetch(:base), "trusted base")
 base_history = base.fetch("historicalReleases")
 current_history = current.fetch("historicalReleases")
 
+immutable_authority_fields = ["$schema", "schemaVersion", "schemaID", "product", "releasePolicy"]
+immutable_authority_fields.each do |field|
+  unless current[field] == base[field]
+    abort("error: release-manifest authority field #{field} changed; update the trusted checker in an earlier commit before changing this field")
+  end
+end
+
 unless current_history.length >= base_history.length && current_history.first(base_history.length) == base_history
   abort("error: prior historicalReleases prefix changed; deletion, mutation, and reorder are forbidden")
 end
@@ -77,6 +84,53 @@ if current_published == base_published
 else
   unless current_history.length == base_history.length + 1 && current_history.last == base_published
     abort("error: previous publishedRelease must be appended unchanged before publishedRelease changes")
+  end
+
+  base_candidate = base["candidate"]
+  unless base_candidate.is_a?(Hash)
+    abort("error: publishedRelease may change only by promoting the trusted base candidate")
+  end
+
+  identity_fields = [
+    "version",
+    "build",
+    "tag",
+    "artifact",
+    "checksumAsset",
+    "artifactSummary",
+    "releaseChecklist"
+  ]
+  identity_fields.each do |field|
+    unless current_published[field] == base_candidate[field]
+      abort("error: promoted publishedRelease must preserve trusted base candidate field #{field}")
+    end
+  end
+
+  if base_candidate["sha256"] && current_published["sha256"] != base_candidate["sha256"]
+    abort("error: promoted publishedRelease sha256 must preserve the trusted base candidate checksum when present")
+  end
+
+  promotion_facts_valid =
+    current_published["sourceCommit"].is_a?(String) &&
+    current_published["sourceCommit"].match?(/\A[0-9a-f]{40}\z/) &&
+    current_published["sourceCIRunID"].is_a?(Integer) &&
+    current_published["sourceCIRunID"].positive? &&
+    current_published["releaseWorkflowRunID"].is_a?(Integer) &&
+    current_published["releaseWorkflowRunID"].positive? &&
+    current_published["sha256"].is_a?(String) &&
+    current_published["sha256"].match?(/\A[0-9a-f]{64}\z/) &&
+    current_published["artifactTrust"] == "passed" &&
+    current_published["signingTrust"] == "developer-id-notarized" &&
+    current_published["tagTrust"] == "signed-verified" &&
+    current_published["installedReleaseReview"] == base_candidate["installedReleaseReview"] &&
+    current_published["manualCompatibility"] == base_candidate["manualCompatibility"] &&
+    current_published["manualCompatibilityScope"] == base_candidate["manualCompatibilityScope"]
+  unless promotion_facts_valid
+    abort("error: promoted publishedRelease must add complete signed publication facts without fabricating post-release review evidence")
+  end
+
+  unless current["candidate"].nil?
+    abort("error: candidate must be cleared when it is promoted into publishedRelease")
   end
 end
 

--- a/scripts/check-release-manifest-history.rb
+++ b/scripts/check-release-manifest-history.rb
@@ -1,0 +1,83 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "digest"
+require "json"
+require "optparse"
+
+GRANDFATHERED_INITIAL_V132_CANONICAL_SHA256 = "74a9b82aeb16afa308c92fad3af6db2bbc0d50fc6ed47b2a3212d2345ab67afa"
+
+options = {
+  current: nil,
+  base: nil,
+  allow_initial_v132: false
+}
+
+OptionParser.new do |parser|
+  parser.banner = "Usage: check-release-manifest-history.rb --current PATH (--base PATH | --allow-initial-v1.3.2)"
+  parser.on("--current PATH") { |value| options[:current] = value }
+  parser.on("--base PATH") { |value| options[:base] = value }
+  parser.on("--allow-initial-v1.3.2") { options[:allow_initial_v132] = true }
+end.parse!
+
+abort("error: --current is required") if options[:current].to_s.empty?
+if options[:base].to_s.empty? == !options[:allow_initial_v132]
+  abort("error: require exactly one of --base or --allow-initial-v1.3.2")
+end
+
+def read_manifest(path, label)
+  data = JSON.parse(File.read(path))
+  abort("error: #{label} release manifest must decode to an object") unless data.is_a?(Hash)
+  abort("error: #{label} historicalReleases must be an array") unless data["historicalReleases"].is_a?(Array)
+  abort("error: #{label} publishedRelease must be an object") unless data["publishedRelease"].is_a?(Hash)
+  data
+rescue Errno::ENOENT
+  abort("error: #{label} release manifest not found: #{path}")
+rescue JSON::ParserError => error
+  abort("error: #{label} release manifest is invalid JSON: #{error.message}")
+end
+
+def deep_sort(value)
+  case value
+  when Hash
+    value.keys.sort.to_h { |key| [key, deep_sort(value.fetch(key))] }
+  when Array
+    value.map { |item| deep_sort(item) }
+  else
+    value
+  end
+end
+
+current = read_manifest(options.fetch(:current), "current")
+
+if options[:allow_initial_v132]
+  canonical_sha = Digest::SHA256.hexdigest(JSON.generate(deep_sort(current)))
+  unless canonical_sha == GRANDFATHERED_INITIAL_V132_CANONICAL_SHA256
+    abort("error: initial manifest does not match grandfathered v1.3.2 boundary")
+  end
+  puts "Release manifest history OK: exact grandfathered v1.3.2 initial boundary"
+  exit 0
+end
+
+base = read_manifest(options.fetch(:base), "trusted base")
+base_history = base.fetch("historicalReleases")
+current_history = current.fetch("historicalReleases")
+
+unless current_history.length >= base_history.length && current_history.first(base_history.length) == base_history
+  abort("error: prior historicalReleases prefix changed; deletion, mutation, and reorder are forbidden")
+end
+
+base_published = base.fetch("publishedRelease")
+current_published = current.fetch("publishedRelease")
+
+if current_published == base_published
+  unless current_history.length == base_history.length
+    abort("error: historicalReleases may grow only when publishedRelease changes")
+  end
+else
+  unless current_history.length == base_history.length + 1 && current_history.last == base_published
+    abort("error: previous publishedRelease must be appended unchanged before publishedRelease changes")
+  end
+end
+
+puts "Release manifest history OK: trusted base prefix and previous published release preserved"


### PR DESCRIPTION
## Summary

- land the trusted release-manifest continuity checker before introducing the manifest
- pin the exact grandfathered v1.3.2 initial boundary
- enforce append-only historical releases and exact previous-published-release promotion
- materialize the checker from the trusted Git base for later manifest validation

This PR intentionally contains only the two checker files. It does not change release metadata, workflows, tags, releases, or app behavior.

## Local verification

- Ruby syntax: passed
- Bash syntax: passed
- exact v1.3.2 initial boundary: passed
- ReleaseManifestScriptTests: 49 passed, 0 failed
- ReleaseMetadataScriptTests: 86 passed, 0 failed