### PR TITLE
Make release prep fixture candidate-aware

### DIFF
--- a/Tests/ViftyCoreTests/ReleaseGovernanceTagBindingTests.swift
+++ b/Tests/ViftyCoreTests/ReleaseGovernanceTagBindingTests.swift
@@ -867,18 +867,17 @@ private final class GovernanceTagFixture {
     }
 
     func amendCandidateWithUnchangedBundleBuild() throws {
-        let manifest = try XCTUnwrap(
-            JSONSerialization.jsonObject(
-                with: Data(
-                    contentsOf: repositoryURL.appendingPathComponent(
-                        ".github/release-manifest.json"
-                    )
-                )
+        let parentPlist = try git("show", "HEAD^:Resources/Info.plist")
+        try Self.requireSuccess(parentPlist, "read first-parent fixture Info.plist")
+        let parentProperties = try XCTUnwrap(
+            PropertyListSerialization.propertyList(
+                from: Data(parentPlist.stdout.utf8),
+                options: [],
+                format: nil
             ) as? [String: Any]
         )
-        let published = try XCTUnwrap(manifest["publishedRelease"] as? [String: Any])
-        let publishedBuild = try XCTUnwrap(published["build"] as? Int)
-        try editInfoPlist("Set :CFBundleVersion \(publishedBuild)")
+        let parentBuild = try XCTUnwrap(parentProperties["CFBundleVersion"] as? String)
+        try editInfoPlist("Set :CFBundleVersion \(parentBuild)")
         try amendCandidate(staging: ["Resources/Info.plist"])
     }
 
@@ -1104,9 +1103,19 @@ private final class GovernanceTagFixture {
         )
         let published = try XCTUnwrap(manifest["publishedRelease"] as? [String: Any])
         let publishedBuild = try XCTUnwrap(published["build"] as? Int)
+        let baseInfoPlist = try XCTUnwrap(
+            PropertyListSerialization.propertyList(
+                from: Data(contentsOf: repositoryURL.appendingPathComponent("Resources/Info.plist")),
+                options: [],
+                format: nil
+            ) as? [String: Any]
+        )
+        let baseBuildString = try XCTUnwrap(baseInfoPlist["CFBundleVersion"] as? String)
+        let baseBuild = try XCTUnwrap(Int(baseBuildString))
+        let candidateBuild = max(publishedBuild, baseBuild) + 1
         manifest["candidate"] = [
             "version": String(tag.dropFirst()),
-            "build": publishedBuild + 1,
+            "build": candidateBuild,
             "tag": tag,
             "artifact": "Vifty-\(tag).zip",
             "checksumAsset": "Vifty-\(tag).zip.sha256",
@@ -1139,7 +1148,7 @@ private final class GovernanceTagFixture {
         try Self.requireSuccess(
             try Self.run(
                 "/usr/libexec/PlistBuddy",
-                ["-c", "Set :CFBundleVersion \(publishedBuild + 1)", infoPlistURL.path],
+                ["-c", "Set :CFBundleVersion \(candidateBuild)", infoPlistURL.path],
                 currentDirectory: repositoryURL
             ),
             "set fixture candidate build"


### PR DESCRIPTION
## Outcome

Keeps the signed release-prep governance fixture valid whether the checkout plist still reflects the published build or already contains a staged candidate build.

## Change

- Derive the synthetic candidate build above both the published manifest build and the fixture base plist build.
- Make the unchanged-build negative case restore the exact first-parent plist build instead of assuming it equals the published build.

## Verification

- `ReleaseGovernanceTagBindingTests`: 29/29 passed.
- The two affected cases: 2/2 passed with the exact stashed v1.4.0 candidate applied in an isolated worktree.
- Independent review: no blockers.

This prerequisite deliberately lands before the exact-four-file v1.4.0 release-prep commit; no release metadata is changed here.