### PR TITLE
Canonicalize GitHub ruleset revision timestamps

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -470,7 +470,7 @@ jobs:
                 -H 'Pragma: no-cache' \
                 "https://api.github.com/repos/${GITHUB_REPOSITORY}/rulesets/${expected_ruleset_id}" \
                 > "${details_path}"
-            ruby -rjson -e '
+            ruby -rjson -rtime -e '
               ruleset = JSON.parse(File.read(ARGV.fetch(0)))
               expected_id = Integer(ARGV.fetch(1), 10)
               expected_updated_at = ARGV.fetch(2)
@@ -484,10 +484,19 @@ jobs:
               rule_types = Array(ruleset["rules"]).map { |rule| rule["type"] }.compact.uniq.sort
               matched_includes = includes == ["refs/tags/v*"] ? includes : []
               matched_excludes = excludes == [] ? [] : Array(excludes)
+              raw_updated_at = ruleset["updated_at"]
+              abort("public ruleset updated_at must be an exact ISO-8601 timestamp with timezone") unless
+                raw_updated_at.is_a?(String) &&
+                raw_updated_at.match?(/\A\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,9})?(?:Z|[+-]\d{2}:\d{2})\z/)
+              begin
+                live_updated_at = Time.iso8601(raw_updated_at).utc.iso8601(9)
+              rescue ArgumentError
+                abort("public ruleset updated_at must be a valid ISO-8601 timestamp with timezone")
+              end
               valid = ruleset["id"] == expected_id &&
                 ruleset["name"].is_a?(String) && !ruleset["name"].empty? &&
                 ruleset["target"] == "tag" && ruleset["enforcement"] == "active" &&
-                ruleset["updated_at"] == expected_updated_at &&
+                live_updated_at == expected_updated_at &&
                 ruleset["current_user_can_bypass"] == "never" &&
                 includes == ["refs/tags/v*"] && matched_includes == ["refs/tags/v*"] &&
                 excludes == [] && matched_excludes.empty? &&
@@ -500,7 +509,7 @@ jobs:
                 "releaseRef" => full_ref,
                 "rulesetID" => expected_id,
                 "rulesetName" => ruleset.fetch("name"),
-                "rulesetUpdatedAt" => ruleset.fetch("updated_at"),
+                "rulesetUpdatedAt" => live_updated_at,
                 "currentUserCanBypass" => ruleset.fetch("current_user_can_bypass"),
                 "target" => "tag",
                 "enforcement" => "active",
@@ -1224,7 +1233,7 @@ jobs:
                   -H 'Pragma: no-cache' \
                   "https://api.github.com/repos/${GITHUB_REPOSITORY}/rulesets/${ruleset_id}" \
                   > "${details_path}"
-              if ruby -rjson -e '
+              if ruby -rjson -rtime -e '
                 ruleset = JSON.parse(File.read(ARGV.fetch(0)))
                 tag = ARGV.fetch(1)
                 expected_id = ARGV.fetch(2)
@@ -1234,10 +1243,19 @@ jobs:
                 includes = ref_name.is_a?(Hash) ? ref_name["include"] : nil
                 excludes = ref_name.is_a?(Hash) ? ref_name["exclude"] : nil
                 rule_types = Array(ruleset["rules"]).map { |rule| rule["type"] }.compact
+                raw_updated_at = ruleset["updated_at"]
+                exit 1 unless
+                  raw_updated_at.is_a?(String) &&
+                  raw_updated_at.match?(/\A\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,9})?(?:Z|[+-]\d{2}:\d{2})\z/)
+                begin
+                  live_updated_at = Time.iso8601(raw_updated_at).utc.iso8601(9)
+                rescue ArgumentError
+                  exit 1
+                end
                 valid = ruleset["target"] == "tag" &&
                   ruleset["enforcement"] == "active" &&
                   (expected_id.empty? || ruleset["id"] == Integer(expected_id, 10)) &&
-                  (expected_updated_at.empty? || ruleset["updated_at"] == expected_updated_at) &&
+                  (expected_updated_at.empty? || live_updated_at == expected_updated_at) &&
                   ruleset["current_user_can_bypass"] == "never" &&
                   includes == ["refs/tags/v*"] &&
                   excludes == [] &&

--- a/Tests/Ruby/WorkflowContractTests.rb
+++ b/Tests/Ruby/WorkflowContractTests.rb
@@ -228,8 +228,20 @@ class WorkflowContractTests < Minitest::Test
 
   def test_rejects_public_ruleset_revision_binding_drift
     mutate_release_workflow(
-      'ruleset["updated_at"] == expected_updated_at',
-      'ruleset["updated_at"].is_a?(String)'
+      'live_updated_at == expected_updated_at',
+      'live_updated_at.is_a?(String)'
+    )
+
+    assert_contract_failure(
+      "sign-notarize must bind final annotated-tag identity and honest public update/deletion " \
+      "ruleset evidence into the publication contract"
+    )
+  end
+
+  def test_rejects_public_ruleset_revision_canonicalization_drift
+    mutate_release_workflow(
+      'live_updated_at = Time.iso8601(raw_updated_at).utc.iso8601(9)',
+      'live_updated_at = Time.iso8601(raw_updated_at).utc.iso8601'
     )
 
     assert_contract_failure(

--- a/Tests/ViftyCoreTests/ReleaseGovernanceScriptTests.swift
+++ b/Tests/ViftyCoreTests/ReleaseGovernanceScriptTests.swift
@@ -39,12 +39,52 @@ final class ReleaseGovernanceScriptTests: XCTestCase {
         let ruleset = try XCTUnwrap(summary["tagRulesetEvidence"] as? [String: Any])
         XCTAssertEqual(ruleset["excludePatternsVerified"] as? Bool, true)
         XCTAssertEqual(ruleset["bypassActorsVerified"] as? Bool, true)
-        XCTAssertEqual(ruleset["rulesetUpdatedAt"] as? String, "2026-01-01T00:00:00Z")
+        XCTAssertEqual(ruleset["rulesetUpdatedAt"] as? String, "2026-01-01T00:00:00.000000000Z")
         XCTAssertEqual(ruleset["currentUserCanBypass"] as? String, "never")
         XCTAssertTrue(try XCTUnwrap(ruleset["bypassActors"] as? [Any]).isEmpty)
         let secrets = try XCTUnwrap(summary["releaseSecrets"] as? [String: Any])
         XCTAssertEqual(secrets["storageScope"] as? String, "repository")
         XCTAssertTrue(try XCTUnwrap(secrets["environmentShadowNames"] as? [Any]).isEmpty)
+    }
+
+    func testAdministratorPreTagGateCanonicalizesRulesetRevisionWithoutLosingPrecision() throws {
+        let cases = [
+            (
+                "2026-07-14T18:23:49.241+02:00",
+                "2026-07-14T16:23:49.241000000Z"
+            ),
+            (
+                "2026-07-14T16:23:49.241Z",
+                "2026-07-14T16:23:49.241000000Z"
+            ),
+            (
+                "2026-07-14T16:23:49.242Z",
+                "2026-07-14T16:23:49.242000000Z"
+            )
+        ]
+
+        for (input, expected) in cases {
+            let fixture = try ReleaseGovernanceFixture(rulesetUpdatedAt: input)
+            let result = try runChecker(fixture)
+
+            XCTAssertEqual(result.exitCode, 0, result.stderr)
+            let summary = try XCTUnwrap(
+                JSONSerialization.jsonObject(with: Data(result.stdout.utf8)) as? [String: Any]
+            )
+            let ruleset = try XCTUnwrap(summary["tagRulesetEvidence"] as? [String: Any])
+            XCTAssertEqual(ruleset["rulesetUpdatedAt"] as? String, expected)
+        }
+    }
+
+    func testAdministratorPreTagGateRejectsRulesetRevisionBeyondNanosecondPrecision() throws {
+        let fixture = try ReleaseGovernanceFixture(
+            rulesetUpdatedAt: "2026-07-14T16:23:49.2410000001Z"
+        )
+
+        let result = try runChecker(fixture)
+
+        XCTAssertEqual(result.exitCode, 65)
+        XCTAssertTrue(result.stderr.contains("malformed or incomplete"), result.stderr)
     }
 
     func testAdministratorPreTagGateRejectsRulesetWithoutVisibleBypassEvidence() throws {

--- a/Tests/ViftyCoreTests/ReleaseGovernanceTagBindingTests.swift
+++ b/Tests/ViftyCoreTests/ReleaseGovernanceTagBindingTests.swift
@@ -27,6 +27,42 @@ final class ReleaseGovernanceTagBindingTests: XCTestCase {
         XCTAssertEqual(summary["evidenceSHA256"] as? String, fixture.evidenceSHA256)
     }
 
+    func testValidatorAcceptsCanonicalNanosecondRulesetRevisionAndRejectsOtherForms() throws {
+        let fixture = try GovernanceTagFixture(sourceRoot: repositoryRoot)
+        var ruleset = try XCTUnwrap(fixture.evidence["tagRulesetEvidence"] as? [String: Any])
+        ruleset["rulesetUpdatedAt"] = "2026-01-01T00:00:00.241000000Z"
+        fixture.evidence["tagRulesetEvidence"] = ruleset
+        try fixture.writeEvidence()
+
+        var result = try fixture.runValidator(taggerTime: fixture.observedAt)
+        XCTAssertEqual(result.exitCode, 0, result.stderr)
+
+        for noncanonical in [
+            "2026-01-01T00:00:00.241Z",
+            "2026-01-01T02:00:00.241000000+02:00"
+        ] {
+            ruleset["rulesetUpdatedAt"] = noncanonical
+            fixture.evidence["tagRulesetEvidence"] = ruleset
+            try fixture.writeEvidence()
+            result = try fixture.runValidator(taggerTime: fixture.observedAt)
+            XCTAssertEqual(result.exitCode, 65)
+            XCTAssertTrue(result.stderr.contains("rulesetUpdatedAt"), result.stderr)
+        }
+    }
+
+    func testValidatorKeepsFreshnessTimestampsAtCanonicalWholeSecondPrecision() throws {
+        let fixture = try GovernanceTagFixture(sourceRoot: repositoryRoot)
+        fixture.evidence["observationStartedAt"] = "2026-01-01T00:00:00.900000000Z"
+        fixture.evidence["observedAt"] = "2026-01-01T00:00:00.100000000Z"
+        try fixture.writeEvidence()
+
+        let result = try fixture.runValidator(taggerTime: fixture.observedAt)
+
+        XCTAssertEqual(result.exitCode, 65)
+        XCTAssertTrue(result.stderr.contains("observationStartedAt"), result.stderr)
+        XCTAssertTrue(result.stderr.contains("YYYY-MM-DDTHH:MM:SSZ"), result.stderr)
+    }
+
     func testFixtureGovernanceProducerOutputIsMarkedAndRejectedByProductionValidator() throws {
         let fixture = try GovernanceTagFixture(sourceRoot: repositoryRoot)
 

--- a/scripts/check-release-governance.sh
+++ b/scripts/check-release-governance.sh
@@ -379,9 +379,14 @@ collect_matching_ruleset_evidence() {
       abort("active tag ruleset bypass_actors must be visible") unless bypass.is_a?(Array)
       abort("active tag ruleset rules must be visible objects") unless
         rules.is_a?(Array) && rules.all? { |rule| rule.is_a?(Hash) && rule["type"].is_a?(String) }
-      abort("active tag ruleset updated_at must be an exact UTC timestamp") unless
-        updated_at.is_a?(String) && updated_at.match?(/\A\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z\z/) &&
-        Time.iso8601(updated_at).utc.iso8601 == updated_at
+      abort("active tag ruleset updated_at must be an exact ISO-8601 timestamp with timezone") unless
+        updated_at.is_a?(String) &&
+        updated_at.match?(/\A\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,9})?(?:Z|[+-]\d{2}:\d{2})\z/)
+      begin
+        canonical_updated_at = Time.iso8601(updated_at).utc.iso8601(9)
+      rescue ArgumentError
+        abort("active tag ruleset updated_at must be a valid ISO-8601 timestamp with timezone")
+      end
       abort("active tag ruleset current_user_can_bypass must be visible") unless current_user_can_bypass.is_a?(String)
       rule_types = rules.map { |rule| rule.fetch("type") }.uniq.sort
       exit 10 unless includes == ["refs/tags/v*"] && excludes == []
@@ -394,7 +399,7 @@ collect_matching_ruleset_evidence() {
         "releaseRef" => full_ref,
         "rulesetID" => ruleset.fetch("id"),
         "rulesetName" => ruleset.fetch("name"),
-        "rulesetUpdatedAt" => updated_at,
+        "rulesetUpdatedAt" => canonical_updated_at,
         "currentUserCanBypass" => current_user_can_bypass,
         "target" => "tag",
         "enforcement" => "active",

--- a/scripts/check-workflow-contract.rb
+++ b/scripts/check-workflow-contract.rb
@@ -367,7 +367,8 @@ else
          release_governance_checker_text.include?('"releaseAuthorized" => !fixture_mode') &&
          release_governance_checker_text.include?('"dataSource" => fixture_mode ? "test-fixture" : "github-api-live"') &&
          release_governance_checker_text.include?('repo.dig("permissions", "admin") == true') &&
-         release_governance_checker_text.include?('"rulesetUpdatedAt" => updated_at') &&
+         release_governance_checker_text.include?('canonical_updated_at = Time.iso8601(updated_at).utc.iso8601(9)') &&
+         release_governance_checker_text.include?('"rulesetUpdatedAt" => canonical_updated_at') &&
          release_governance_checker_text.include?('"currentUserCanBypass" => current_user_can_bypass') &&
          release_governance_checker_text.include?('current_user_can_bypass == "never"') &&
          release_governance_checker_text.include?('includes == ["refs/tags/v*"] && excludes == []') &&
@@ -1004,7 +1005,7 @@ else
       "Import Developer ID certificate" => "c1d39d72865189a04b4d529ee8ccda1abb42ddff304466d8abcbf45d3bea4147",
       "Revalidate trusted tooling and sign existing candidate" => "ba4561b4ab6926f6dd028f634b2f0c79a36d24aba14cc12a1386f6eec929401f",
       "Notarize signed candidate" => "f5050e48f720d04083c7d15f22bf82f72cc2f822d23ef08d0761a09fe3a316a7",
-      "Create and verify release assets with trusted tools" => "449aea8782a888719e592bc48ba75d2c27df5c1809c4ee9be07e5a9f8b9f2b4e",
+      "Create and verify release assets with trusted tools" => "0619d4252a470afea71054a535385dd864d98656c06ad9e3849f404a4d94c238",
       "Remove signing material" => "4df2d7fa1538a8e0017e92932873c0bf76dd6984e000ac1bfd9795c6263040c1",
       "Upload verified release assets for publication" => "ce920891b00c02cc279f139e1823cbdb94f025d8588d771b607747c77eb09e34"
     }
@@ -1188,7 +1189,8 @@ else
            run_text.include?('ruleset_evidence["rulesetID"] == governance_validation["rulesetID"]') &&
            run_text.include?('ruleset_evidence["rulesetUpdatedAt"] == governance_validation["rulesetUpdatedAt"]') &&
            run_text.include?('ruleset_evidence["currentUserCanBypass"] == "never"') &&
-           run_text.include?('ruleset["updated_at"] == expected_updated_at') &&
+           run_text.include?('live_updated_at = Time.iso8601(raw_updated_at).utc.iso8601(9)') &&
+           run_text.include?('live_updated_at == expected_updated_at') &&
            run_text.include?('ruleset["current_user_can_bypass"] == "never"') &&
            run_text.include?('"bypassActorsVerified" => false') &&
            run_text.include?('full_ref = "refs/tags/#{tag}"') &&
@@ -1243,7 +1245,7 @@ else
     expected_step_hashes = {
       "Download verified release assets" => "2efd54639fbb126e0ce7aa6fcb477987a276e7b0a98d6ecfb745a1b25df99dc8",
       "Recheck downloaded asset identity" => "aa5a51382d16e1ad1b73abec06a173c75673c05b43bad9ccf55e664aa7573c00",
-      "Publish GitHub release" => "295a32714cb87b4b0a252275e76b8677102127c53f8cb91bc1eaa61a258bd9ca"
+      "Publish GitHub release" => "6cfcb858c1f9e062754cd855400f815626db74295c828e4ec5fdfd5c977570ae"
     }
     names = steps.map { |step| step.is_a?(Hash) ? step["name"] : nil }
     errors << "publish step set must match the reviewed allowlist exactly" unless names == expected_step_hashes.keys
@@ -1330,7 +1332,8 @@ else
     unless publish_run_text.include?("verify_immutable_tag_ruleset()") &&
            publish_run_text.scan("verify_immutable_tag_ruleset").length >= 4 &&
            !publish_run_text.include?('ruleset["bypass_actors"]') &&
-           publish_run_text.include?('ruleset["updated_at"] == expected_updated_at') &&
+           publish_run_text.include?('live_updated_at = Time.iso8601(raw_updated_at).utc.iso8601(9)') &&
+           publish_run_text.include?('live_updated_at == expected_updated_at') &&
            publish_run_text.include?('ruleset["current_user_can_bypass"] == "never"') &&
            publish_run_text.include?('full_ref = "refs/tags/#{tag}"') &&
            publish_run_text.include?('includes == ["refs/tags/v*"]') &&

--- a/scripts/validate-release-governance-evidence.rb
+++ b/scripts/validate-release-governance-evidence.rb
@@ -100,6 +100,21 @@ rescue ArgumentError
   fail_evidence("#{label} is not a valid UTC timestamp")
 end
 
+def parse_ruleset_revision(value, label)
+  unless value.is_a?(String) &&
+         value.match?(/\A\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{9})?Z\z/)
+    fail_evidence(
+      "#{label} must be canonical UTC with whole-second or nanosecond precision"
+    )
+  end
+  parsed = Time.iso8601(value).utc
+  precision = value.include?(".") ? 9 : 0
+  fail_evidence("#{label} must be a canonical UTC timestamp") unless parsed.iso8601(precision) == value
+  parsed
+rescue ArgumentError
+  fail_evidence("#{label} is not a valid UTC timestamp")
+end
+
 def git_output(root, *arguments)
   stdout, stderr, status = Open3.capture3("/usr/bin/git", "-C", root, *arguments)
   fail_evidence("git #{arguments.join(' ')} failed: #{stderr.strip}") unless status.success?
@@ -313,7 +328,7 @@ begin
   ruleset_id = ruleset["rulesetID"]
   fail_evidence("tagRulesetEvidence.rulesetID must be a positive integer") unless ruleset_id.is_a?(Integer) && ruleset_id.positive?
   fail_evidence("tagRulesetEvidence.rulesetName must be non-empty") unless ruleset["rulesetName"].is_a?(String) && !ruleset["rulesetName"].empty?
-  ruleset_updated_at = parse_utc_time(
+  ruleset_updated_at = parse_ruleset_revision(
     ruleset["rulesetUpdatedAt"],
     "tagRulesetEvidence.rulesetUpdatedAt"
   )
@@ -321,7 +336,7 @@ begin
   require_exact(
     ruleset,
     "rulesetUpdatedAt",
-    ruleset_updated_at.iso8601,
+    ruleset_updated_at.iso8601(ruleset.fetch("rulesetUpdatedAt").include?(".") ? 9 : 0),
     "tagRulesetEvidence.rulesetUpdatedAt"
   )
   require_exact(ruleset, "currentUserCanBypass", "never", "tagRulesetEvidence.currentUserCanBypass")


### PR DESCRIPTION
## Summary

- canonicalize GitHub ruleset revision timestamps to fixed nine-digit UTC before binding them into administrator evidence
- compare the same canonical revision in both protected Release workflow readbacks
- keep tagger, observation, and freshness timestamps at whole-second UTC precision
- preserve validation of historical whole-second ruleset evidence

## Why

GitHub currently returns ruleset 18940029 updated_at as 2026-07-14T18:23:49.241+02:00. The previous checker accepted only whole-second UTC and therefore failed closed even though the immutable v* policy was otherwise correct.

## Evidence

- live read-only governance probe passes and emits 2026-07-14T16:23:49.241000000Z
- 18 ReleaseGovernanceScriptTests passed
- targeted ruleset revision, whole-second freshness, and existing freshness tests passed
- workflow contract checker passed
- 52 Ruby workflow-contract tests / 307 assertions passed
- actionlint and shell/Ruby syntax checks passed
- independent security review found no remaining blocker after the ruleset-specific parser split

The repository disk guard is currently below 30 GiB, so the full local suite was deliberately not started; this PR's required GitHub CI remains the full authoritative gate.
