### PR TITLE
Fix release run integration gates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -226,14 +226,17 @@ jobs:
           )
           VIFTY_WORKFLOW_CONTRACT_ROOT="${TRUSTED_ROOT}" \
             ruby "${TRUSTED_ROOT}/scripts/check-workflow-contract.rb"
-          GH_TOKEN="${RELEASE_GH_TOKEN}" \
-            "${TRUSTED_ROOT}/scripts/check-release-environment.sh" \
-            --repo "${GITHUB_REPOSITORY}" \
-            --environment release \
-            --branch main \
-            --workflow-public \
-            --expected-branch-sha "${GITHUB_SHA}" \
-            --output "${RUNNER_TEMP}/vifty-release-environment-readback.json"
+          (
+            cd "${TRUSTED_ROOT}"
+            GH_TOKEN="${RELEASE_GH_TOKEN}" \
+              "${TRUSTED_ROOT}/scripts/check-release-environment.sh" \
+              --repo "${GITHUB_REPOSITORY}" \
+              --environment release \
+              --branch main \
+              --workflow-public \
+              --expected-branch-sha "${GITHUB_SHA}" \
+              --output "${RUNNER_TEMP}/vifty-release-environment-readback.json"
+          )
           unset RELEASE_GH_TOKEN
 
       - name: Download inventoried candidate

--- a/Tests/Ruby/WorkflowContractTests.rb
+++ b/Tests/Ruby/WorkflowContractTests.rb
@@ -84,6 +84,19 @@ class WorkflowContractTests < Minitest::Test
     )
   end
 
+  def test_rejects_release_environment_checker_outside_trusted_worktree
+    mutate_release_workflow(
+      "            cd \"${TRUSTED_ROOT}\"\n" \
+      "            GH_TOKEN=\"${RELEASE_GH_TOKEN}\"",
+      "            cd \"${GITHUB_WORKSPACE}\"\n" \
+      "            GH_TOKEN=\"${RELEASE_GH_TOKEN}\""
+    )
+
+    assert_contract_failure(
+      "sign-notarize release-environment checker must execute from the exact trusted worktree"
+    )
+  end
+
   def test_rejects_checkout_not_bound_to_exact_pushed_tag
     mutate_release_workflow(
       '          ref: refs/tags/${{ github.ref_name }}',

--- a/Tests/ViftyCoreTests/ReleaseEnvironmentScriptTests.swift
+++ b/Tests/ViftyCoreTests/ReleaseEnvironmentScriptTests.swift
@@ -547,6 +547,8 @@ final class ReleaseEnvironmentScriptTests: XCTestCase {
         XCTAssertTrue(workflow.contains("vifty-release-environment-readback.json"))
         XCTAssertTrue(workflow.contains("--workflow-public"))
         XCTAssertTrue(workflow.contains("--expected-branch-sha \"${GITHUB_SHA}\""))
+        XCTAssertTrue(workflow.contains("cd \"${TRUSTED_ROOT}\""))
+        XCTAssertTrue(workflow.contains("\"${TRUSTED_ROOT}/scripts/check-release-environment.sh\""))
         XCTAssertTrue(workflow.contains("releaseEnvironmentEvidence"))
         XCTAssertTrue(workflow.contains(#"environment_evidence["evidenceScope"] == "workflow-public""#))
         XCTAssertTrue(workflow.contains(#"environment_evidence["privilegedSettingsVerified"] == false"#))

--- a/Tests/ViftyCoreTests/ReleaseManifestScriptTests.swift
+++ b/Tests/ViftyCoreTests/ReleaseManifestScriptTests.swift
@@ -201,6 +201,121 @@ final class ReleaseManifestScriptTests: XCTestCase {
         XCTAssertTrue(result.stderr.contains("historicalReleases must be append-ordered by increasing version and build"), result.stderr)
     }
 
+    func testHistoryCheckerAcceptsUnchangedTrustedCandidate() throws {
+        let fixture = try ReleaseManifestFixture(repositoryRoot: repositoryRoot)
+        try fixture.mutateManifest { manifest in
+            manifest["candidate"] = self.candidateEntry(version: "1.3.3", build: 8)
+        }
+        try fixture.snapshotCurrentAsBase()
+
+        let result = try fixture.runHistoryChecker()
+
+        XCTAssertEqual(result.exitCode, 0, result.stderr)
+    }
+
+    func testHistoryCheckerAcceptsFirstCandidateAfterNullBase() throws {
+        let fixture = try ReleaseManifestFixture(repositoryRoot: repositoryRoot)
+        try fixture.mutateManifest { manifest in
+            manifest["candidate"] = NSNull()
+        }
+        try fixture.snapshotCurrentAsBase()
+        try fixture.mutateManifest { manifest in
+            manifest["candidate"] = self.candidateEntry(version: "1.3.3", build: 8)
+        }
+
+        let result = try fixture.runHistoryChecker()
+
+        XCTAssertEqual(result.exitCode, 0, result.stderr)
+    }
+
+    func testHistoryCheckerAcceptsStrictlyNewerCandidateReplacement() throws {
+        let fixture = try ReleaseManifestFixture(repositoryRoot: repositoryRoot)
+        try fixture.mutateManifest { manifest in
+            manifest["candidate"] = self.candidateEntry(version: "1.4.0", build: 8)
+        }
+        try fixture.snapshotCurrentAsBase()
+        try fixture.mutateManifest { manifest in
+            manifest["candidate"] = self.candidateEntry(version: "1.4.1", build: 9)
+        }
+
+        let result = try fixture.runHistoryChecker()
+
+        XCTAssertEqual(result.exitCode, 0, result.stderr)
+    }
+
+    func testHistoryCheckerRejectsReplacementCandidateVersionThatDoesNotIncrease() throws {
+        for replacementVersion in ["1.3.9", "1.4.0"] {
+            let fixture = try ReleaseManifestFixture(repositoryRoot: repositoryRoot)
+            try fixture.mutateManifest { manifest in
+                manifest["candidate"] = self.candidateEntry(version: "1.4.0", build: 8)
+            }
+            try fixture.snapshotCurrentAsBase()
+            try fixture.mutateManifest { manifest in
+                manifest["candidate"] = self.candidateEntry(
+                    version: replacementVersion,
+                    build: 9
+                )
+            }
+
+            let result = try fixture.runHistoryChecker()
+
+            XCTAssertNotEqual(result.exitCode, 0)
+            XCTAssertTrue(
+                result.stderr.contains(
+                    "replacement candidate version \(replacementVersion) must be newer than trusted base candidate 1.4.0"
+                ),
+                result.stderr
+            )
+        }
+    }
+
+    func testHistoryCheckerRejectsReplacementCandidateBuildThatDoesNotIncrease() throws {
+        for replacementBuild in [8, 9] {
+            let fixture = try ReleaseManifestFixture(repositoryRoot: repositoryRoot)
+            try fixture.mutateManifest { manifest in
+                manifest["candidate"] = self.candidateEntry(version: "1.4.0", build: 9)
+            }
+            try fixture.snapshotCurrentAsBase()
+            try fixture.mutateManifest { manifest in
+                manifest["candidate"] = self.candidateEntry(
+                    version: "1.4.1",
+                    build: replacementBuild
+                )
+            }
+
+            let result = try fixture.runHistoryChecker()
+
+            XCTAssertNotEqual(result.exitCode, 0)
+            XCTAssertTrue(
+                result.stderr.contains(
+                    "replacement candidate build \(replacementBuild) must be greater than trusted base candidate build 9"
+                ),
+                result.stderr
+            )
+        }
+    }
+
+    func testHistoryCheckerRejectsClearingUnpromotedCandidate() throws {
+        let fixture = try ReleaseManifestFixture(repositoryRoot: repositoryRoot)
+        try fixture.mutateManifest { manifest in
+            manifest["candidate"] = self.candidateEntry(version: "1.3.3", build: 8)
+        }
+        try fixture.snapshotCurrentAsBase()
+        try fixture.mutateManifest { manifest in
+            manifest["candidate"] = NSNull()
+        }
+
+        let result = try fixture.runHistoryChecker()
+
+        XCTAssertNotEqual(result.exitCode, 0)
+        XCTAssertTrue(
+            result.stderr.contains(
+                "unpromoted trusted base candidate may be cleared only by promotion"
+            ),
+            result.stderr
+        )
+    }
+
     func testHistoryCheckerAcceptsExactTrustedCandidatePromotion() throws {
         let fixture = try ReleaseManifestFixture(repositoryRoot: repositoryRoot)
         try fixture.mutateManifest { manifest in

--- a/Tests/ViftyCoreTests/ReleaseProvenanceScriptTests.swift
+++ b/Tests/ViftyCoreTests/ReleaseProvenanceScriptTests.swift
@@ -112,7 +112,7 @@ final class ReleaseProvenanceScriptTests: XCTestCase {
         let result = try fixture.runChecker()
 
         XCTAssertNotEqual(result.exitCode, 0)
-        XCTAssertTrue(result.stderr.contains("does not match v1.3.3 commit"), result.stderr)
+        XCTAssertTrue(result.stderr.contains("does not match \(fixture.tag) commit"), result.stderr)
     }
 
     func testCheckerRejectsTrustedWorkflowRefAfterSignedTagCommit() throws {
@@ -191,11 +191,11 @@ final class ReleaseProvenanceScriptTests: XCTestCase {
 
     func testCheckerRejectsGovernanceOutputInsideGitMetadataWithoutChangingTagRef() throws {
         let fixture = try ReleaseProvenanceFixture()
-        let tagRef = fixture.rootURL.appendingPathComponent(".git/refs/tags/v1.3.3")
+        let tagRef = fixture.rootURL.appendingPathComponent(".git/refs/tags/\(fixture.tag)")
         let original = try Data(contentsOf: tagRef)
 
         let result = try fixture.runChecker(
-            governanceEvidenceOutputArgument: ".git/refs/tags/v1.3.3"
+            governanceEvidenceOutputArgument: ".git/refs/tags/\(fixture.tag)"
         )
 
         XCTAssertEqual(result.exitCode, 65)
@@ -364,6 +364,7 @@ private struct RecordedGitHubCall {
 private final class ReleaseProvenanceFixture {
     let rootURL: URL
     let commitSHA: String
+    private(set) var tag = ""
 
     private let ciRunsURL: URL
     private let remoteRefsURL: URL
@@ -443,15 +444,26 @@ private final class ReleaseProvenanceFixture {
             arguments: ["-c", "commit.gpgsign=false", "commit", "-m", "trusted release base"],
             currentDirectory: rootURL
         )
-        try Self.writeCandidateManifest(at: rootURL.appendingPathComponent(".github/release-manifest.json"))
+        let candidate = try Self.writeCandidateManifest(
+            at: rootURL.appendingPathComponent(".github/release-manifest.json")
+        )
+        tag = candidate.tag
         try Self.runRequired(
             executable: "/usr/libexec/PlistBuddy",
-            arguments: ["-c", "Set :CFBundleShortVersionString 1.3.3", rootURL.appendingPathComponent("Resources/Info.plist").path],
+            arguments: [
+                "-c",
+                "Set :CFBundleShortVersionString \(candidate.version)",
+                rootURL.appendingPathComponent("Resources/Info.plist").path
+            ],
             currentDirectory: rootURL
         )
         try Self.runRequired(
             executable: "/usr/libexec/PlistBuddy",
-            arguments: ["-c", "Set :CFBundleVersion 8", rootURL.appendingPathComponent("Resources/Info.plist").path],
+            arguments: [
+                "-c",
+                "Set :CFBundleVersion \(candidate.build)",
+                rootURL.appendingPathComponent("Resources/Info.plist").path
+            ],
             currentDirectory: rootURL
         )
         if changeSignerPolicyInCandidate {
@@ -474,7 +486,8 @@ private final class ReleaseProvenanceFixture {
         try Self.writeGovernanceEvidence(
             at: governanceEvidenceURL,
             rootURL: rootURL,
-            commitSHA: commitSHA
+            commitSHA: commitSHA,
+            tag: tag
         )
         let governanceBytes = try Data(contentsOf: governanceEvidenceURL)
         let tagMessage = "candidate\n\nVifty-Release-Governance-Base64: \(governanceBytes.base64EncodedString())"
@@ -484,10 +497,10 @@ private final class ReleaseProvenanceFixture {
                 "-c", "gpg.format=ssh",
                 "-c", "gpg.ssh.program=/usr/bin/ssh-keygen",
                 "-c", "user.signingkey=\(supportURL.appendingPathComponent("release-signing-key").path)",
-                "tag", "-s", "v1.3.3", "-m", tagMessage
+                "tag", "-s", tag, "-m", tagMessage
             ]
         } else {
-            tagArguments = ["-c", "tag.gpgSign=false", "tag", "-a", "v1.3.3", "-m", tagMessage]
+            tagArguments = ["-c", "tag.gpgSign=false", "tag", "-a", tag, "-m", tagMessage]
         }
         try Self.runRequired(
             executable: "/usr/bin/git",
@@ -496,7 +509,7 @@ private final class ReleaseProvenanceFixture {
         )
         let tagObjectSHA = try Self.capture(
             executable: "/usr/bin/git",
-            arguments: ["rev-parse", "v1.3.3^{tag}"],
+            arguments: ["rev-parse", "\(tag)^{tag}"],
             currentDirectory: rootURL
         ).trimmingCharacters(in: .whitespacesAndNewlines)
         try Self.writeJSON(
@@ -504,7 +517,7 @@ private final class ReleaseProvenanceFixture {
             to: remoteRefsURL
         )
         if liveGitHubMode != nil {
-            try "v1.3.3\n".write(
+            try "\(tag)\n".write(
                 to: supportURL.appendingPathComponent("tag-name"),
                 atomically: true,
                 encoding: .utf8
@@ -601,7 +614,7 @@ private final class ReleaseProvenanceFixture {
     }
 
     func runChecker(
-        tag: String = "v1.3.3",
+        tag: String? = nil,
         json: Bool = false,
         trustedWorkflowRef: String? = nil,
         governanceEvidenceOutput: URL? = nil,
@@ -616,7 +629,7 @@ private final class ReleaseProvenanceFixture {
         process.executableURL = rootURL.appendingPathComponent("scripts/check-release-provenance.sh")
         process.currentDirectoryURL = currentDirectoryURL ?? rootURL
         var arguments = [
-            "--tag", tag,
+            "--tag", tag ?? self.tag,
             "--main-ref", "main"
         ]
         if includeCIRunsFixture {
@@ -840,17 +853,45 @@ private final class ReleaseProvenanceFixture {
         )
     }
 
-    private static func writeCandidateManifest(at url: URL) throws {
+    private static func writeCandidateManifest(
+        at url: URL
+    ) throws -> (version: String, build: Int, tag: String) {
         let data = try Data(contentsOf: url)
         var manifest = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        let published = try XCTUnwrap(manifest["publishedRelease"] as? [String: Any])
+        let base = (manifest["candidate"] as? [String: Any]) ?? published
+        let baseVersion = try XCTUnwrap(base["version"] as? String)
+        let versionComponents = baseVersion.split(
+            separator: ".",
+            omittingEmptySubsequences: false
+        ).compactMap { Int($0) }
+        guard versionComponents.count == 3 else {
+            throw NSError(
+                domain: "ReleaseProvenanceFixture",
+                code: 3,
+                userInfo: [NSLocalizedDescriptionKey: "base release version is not numeric SemVer"]
+            )
+        }
+        let (nextPatch, versionOverflow) = versionComponents[2].addingReportingOverflow(1)
+        let baseBuild = try XCTUnwrap(base["build"] as? Int)
+        let (candidateBuild, buildOverflow) = baseBuild.addingReportingOverflow(1)
+        guard !versionOverflow, !buildOverflow else {
+            throw NSError(
+                domain: "ReleaseProvenanceFixture",
+                code: 4,
+                userInfo: [NSLocalizedDescriptionKey: "base release identity cannot be incremented"]
+            )
+        }
+        let candidateVersion = "\(versionComponents[0]).\(versionComponents[1]).\(nextPatch)"
+        let candidateTag = "v\(candidateVersion)"
         manifest["candidate"] = [
-            "version": "1.3.3",
-            "build": 8,
-            "tag": "v1.3.3",
-            "artifact": "Vifty-v1.3.3.zip",
-            "checksumAsset": "Vifty-v1.3.3.zip.sha256",
-            "artifactSummary": "Vifty-v1.3.3-artifact-summary.json",
-            "releaseChecklist": "Vifty-v1.3.3-release-checklist.md",
+            "version": candidateVersion,
+            "build": candidateBuild,
+            "tag": candidateTag,
+            "artifact": "Vifty-\(candidateTag).zip",
+            "checksumAsset": "Vifty-\(candidateTag).zip.sha256",
+            "artifactSummary": "Vifty-\(candidateTag)-artifact-summary.json",
+            "releaseChecklist": "Vifty-\(candidateTag)-release-checklist.md",
             "sha256": NSNull(),
             "artifactTrust": "pending",
             "signingTrust": "pending",
@@ -860,12 +901,14 @@ private final class ReleaseProvenanceFixture {
             "manualCompatibilityScope": NSNull()
         ]
         try writeJSON(manifest, to: url)
+        return (candidateVersion, candidateBuild, candidateTag)
     }
 
     private static func writeGovernanceEvidence(
         at url: URL,
         rootURL: URL,
-        commitSHA: String
+        commitSHA: String,
+        tag: String
     ) throws {
         let toolSHA = try capture(
             executable: "/usr/bin/shasum",
@@ -906,7 +949,7 @@ private final class ReleaseProvenanceFixture {
             "dataSource": "github-api-live",
             "liveAuthenticatedGitHubReadback": true,
             "repository": "Reedtrullz/Vifty",
-            "releaseTag": "v1.3.3",
+            "releaseTag": tag,
             "expectedMainSHA": commitSHA,
             "observationStartedAt": observedAt,
             "observedAt": observedAt,
@@ -985,8 +1028,8 @@ private final class ReleaseProvenanceFixture {
             "tagRulesetEvidence": [
                 "schemaVersion": 1,
                 "repository": "Reedtrullz/Vifty",
-                "releaseTag": "v1.3.3",
-                "releaseRef": "refs/tags/v1.3.3",
+                "releaseTag": tag,
+                "releaseRef": "refs/tags/\(tag)",
                 "rulesetID": 18_940_029,
                 "rulesetName": "Immutable Vifty release tags",
                 "rulesetUpdatedAt": "2026-01-01T00:00:00Z",

--- a/Tests/ViftyCoreTests/ReleasePushDispatchScriptTests.swift
+++ b/Tests/ViftyCoreTests/ReleasePushDispatchScriptTests.swift
@@ -365,6 +365,48 @@ final class ReleasePushDispatchScriptTests: XCTestCase {
         XCTAssertEqual(receipt["triggerCorrelation"] as? String, "observed-unverified")
     }
 
+    func testStaticWorkflowNameMismatchFailsBeforeRemoteMutation() throws {
+        let fixture = try ReleasePushDispatchFixture()
+        try "workflow-name-mismatch".write(
+            to: fixture.modeURL,
+            atomically: true,
+            encoding: .utf8
+        )
+
+        let result = try fixture.runHelper()
+
+        XCTAssertNotEqual(result.exitCode, 0, result.stdout)
+        XCTAssertTrue(result.stderr.contains("release workflow name mismatch"), result.stderr)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: fixture.tagPushedURL.path))
+        XCTAssertFalse(
+            FileManager.default.fileExists(atPath: fixture.retirementMarkerURL.path)
+        )
+        XCTAssertNil(try fixture.remoteTagObject())
+    }
+
+    func testDynamicRunNameMismatchFailsAfterRetiringTag() throws {
+        let fixture = try ReleasePushDispatchFixture()
+        try "run-name-mismatch".write(
+            to: fixture.modeURL,
+            atomically: true,
+            encoding: .utf8
+        )
+
+        let result = try fixture.runHelper()
+
+        XCTAssertNotEqual(result.exitCode, 0, result.stdout)
+        XCTAssertTrue(result.stderr.contains("workflow run does not bind"), result.stderr)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: fixture.tagPushedURL.path))
+        XCTAssertTrue(
+            FileManager.default.fileExists(atPath: fixture.retirementMarkerURL.path)
+        )
+        let receipt = try fixture.receipt()
+        XCTAssertEqual(receipt["status"] as? String, "tag-push-run-mismatched")
+        XCTAssertEqual(receipt["workflowRunObserved"] as? Bool, true)
+        XCTAssertEqual(receipt["workflowRunVerified"] as? Bool, false)
+        XCTAssertEqual(receipt["receiptAuthorizesRetry"] as? Bool, false)
+    }
+
     func testSecondAttemptWorkflowRunIsRejectedWithoutRerun() throws {
         let fixture = try ReleasePushDispatchFixture()
         try "run-attempt-two".write(
@@ -1073,8 +1115,12 @@ private final class ReleasePushDispatchFixture {
                     fi
                     ;;
                   repos/Reedtrullz/Vifty/actions/workflows/release.yml)
-                    /usr/bin/printf '%s\\n' \
-                      '{"id":77,"path":".github/workflows/release.yml","state":"active"}'
+                    workflow_name="Release"
+                    [[ "${mode}" != "workflow-name-mismatch" ]] || \
+                      workflow_name="Unexpected Release"
+                    /usr/bin/printf \
+                      '{"id":77,"name":"%s","path":".github/workflows/release.yml","state":"active"}\\n' \
+                      "${workflow_name}"
                     ;;
                   repos/Reedtrullz/Vifty/actions/runs/555)
                     head_sha="\(commitSHA)"
@@ -1082,10 +1128,12 @@ private final class ReleasePushDispatchFixture {
                       head_sha="bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
                     run_attempt=1
                     [[ "${mode}" != "run-attempt-two" ]] || run_attempt=2
+                    run_name="Release \(tag)"
+                    [[ "${mode}" != "run-name-mismatch" ]] || run_name="Release"
                     created_at="$(/bin/date -u +%Y-%m-%dT%H:%M:%SZ)"
                     /usr/bin/printf \
-                      '{"id":555,"name":"Release","path":".github/workflows/release.yml","display_title":"Release \(tag)","event":"push","head_branch":"\(tag)","head_sha":"%s","run_attempt":%s,"workflow_id":77,"actor":{"id":12345,"login":"Reedtrullz"},"repository":{"full_name":"Reedtrullz/Vifty"},"created_at":"%s","html_url":"https://github.com/Reedtrullz/Vifty/actions/runs/555"}\\n' \
-                      "${head_sha}" "${run_attempt}" "${created_at}"
+                      '{"id":555,"name":"%s","path":".github/workflows/release.yml","display_title":"Release \(tag)","event":"push","head_branch":"\(tag)","head_sha":"%s","run_attempt":%s,"workflow_id":77,"actor":{"id":12345,"login":"Reedtrullz"},"repository":{"full_name":"Reedtrullz/Vifty"},"created_at":"%s","html_url":"https://github.com/Reedtrullz/Vifty/actions/runs/555"}\\n' \
+                      "${run_name}" "${head_sha}" "${run_attempt}" "${created_at}"
                     ;;
                   repos/Reedtrullz/Vifty/git/tags/\(tagObjectSHA))
                     /usr/bin/printf '%s\\n' \

--- a/scripts/check-release-manifest-history.rb
+++ b/scripts/check-release-manifest-history.rb
@@ -48,6 +48,11 @@ def deep_sort(value)
   end
 end
 
+def semver(value)
+  match = /\A(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)\z/.match(value.to_s)
+  match&.captures&.map(&:to_i)
+end
+
 current = read_manifest(options.fetch(:current), "current")
 
 if options[:allow_initial_v132]
@@ -80,6 +85,37 @@ current_published = current.fetch("publishedRelease")
 if current_published == base_published
   unless current_history.length == base_history.length
     abort("error: historicalReleases may grow only when publishedRelease changes")
+  end
+
+  base_candidate = base["candidate"]
+  current_candidate = current["candidate"]
+  if base_candidate.is_a?(Hash) && current_candidate != base_candidate
+    unless current_candidate.is_a?(Hash)
+      abort("error: unpromoted trusted base candidate may be cleared only by promotion")
+    end
+
+    base_candidate_version = semver(base_candidate["version"])
+    current_candidate_version = semver(current_candidate["version"])
+    unless base_candidate_version &&
+           current_candidate_version &&
+           (base_candidate_version <=> current_candidate_version) == -1
+      abort(
+        "error: replacement candidate version #{current_candidate["version"]} " \
+        "must be newer than trusted base candidate #{base_candidate["version"]}"
+      )
+    end
+
+    base_candidate_build = base_candidate["build"]
+    current_candidate_build = current_candidate["build"]
+    unless base_candidate_build.is_a?(Integer) &&
+           base_candidate_build.positive? &&
+           current_candidate_build.is_a?(Integer) &&
+           current_candidate_build > base_candidate_build
+      abort(
+        "error: replacement candidate build #{current_candidate_build} " \
+        "must be greater than trusted base candidate build #{base_candidate_build}"
+      )
+    end
   end
 else
   unless current_history.length == base_history.length + 1 && current_history.last == base_published

--- a/scripts/check-workflow-contract.rb
+++ b/scripts/check-workflow-contract.rb
@@ -677,7 +677,8 @@ else
     push_dispatch_helper_text.include?('"repos/${REPOSITORY}/actions/runs/${RUN_ID}"') &&
     push_dispatch_helper_text.include?('run["id"] == run_id.to_i') &&
     push_dispatch_helper_text.include?('run["workflow_id"] == workflow_id.to_i') &&
-    push_dispatch_helper_text.include?('run["name"] == "Release"') &&
+    push_dispatch_helper_text.include?('workflow["name"] == "Release"') &&
+    push_dispatch_helper_text.include?('run["name"] == "Release #{tag}"') &&
     push_dispatch_helper_text.include?('run["path"] == ".github/workflows/release.yml"') &&
     push_dispatch_helper_text.include?('run["display_title"] == "Release #{tag}"') &&
     push_dispatch_helper_text.include?('run["event"] == "push"') &&
@@ -998,7 +999,7 @@ else
     expected_step_hashes = {
       "Check out trusted release tooling" => "b513361ad57276908ad99e1cf84fe4d93af1cad5e81363a7b22c8487980b9021",
       "Inventory trusted release tooling" => "f8bf25f7e3bba872bcb11b2f0aea575cb502e9f534f372298d3d50efbadf1ffc",
-      "Verify release environment protection" => "0fdba6ffd9ea491017eda7058c693d7cdedb682128f2c61622281f8995f0f617",
+      "Verify release environment protection" => "8a8583cbe1bf9b64edc0f2176cfd016a767e050b5692432a0d32d170a3ad4b7a",
       "Download inventoried candidate" => "48f99fd7a3190b1f735782e9d60f242586636e8a999f4aad431ce9681c1ea829",
       "Verify candidate and trusted tool inventories before secret-consuming steps" => "78e3046f2cb66c12079b9d9fe2a27d343d47cdaa6355959ee1ec535e5801ade2",
       "Require signing and notarization secrets" => "e5421852d3202b04e2aa2ac167915e6806b53a64a257eb6322f60ebfb1e2d892",
@@ -1053,9 +1054,19 @@ else
     environment_step = steps.find { |step| step.is_a?(Hash) && step["name"] == "Verify release environment protection" }
     environment_run = environment_step.is_a?(Hash) ? environment_step["run"].to_s : ""
     environment_env = environment_step.is_a?(Hash) ? environment_step["env"] : nil
+    trusted_environment_invocation = <<~'SHELL'.strip
+      (
+        cd "${TRUSTED_ROOT}"
+        GH_TOKEN="${RELEASE_GH_TOKEN}" \
+          "${TRUSTED_ROOT}/scripts/check-release-environment.sh" \
+    SHELL
+    unless environment_run.include?(trusted_environment_invocation)
+      errors << "sign-notarize release-environment checker must execute from the exact trusted worktree"
+    end
     unless environment_env == { "GH_TOKEN" => "${{ github.token }}" } &&
            environment_run.include?('VIFTY_WORKFLOW_CONTRACT_ROOT="${TRUSTED_ROOT}"') &&
            environment_run.include?('ruby "${TRUSTED_ROOT}/scripts/check-workflow-contract.rb"') &&
+           environment_run.include?('cd "${TRUSTED_ROOT}"') &&
            environment_run.include?('"${TRUSTED_ROOT}/scripts/check-release-environment.sh"') &&
            environment_run.include?('--environment release') &&
            environment_run.include?('--branch main') &&

--- a/scripts/push-and-dispatch-signed-release-tag.sh
+++ b/scripts/push-and-dispatch-signed-release-tag.sh
@@ -871,6 +871,7 @@ active_release_workflow_id() {
     "repos/${REPOSITORY}/actions/workflows/release.yml")"
   "${RUBY_BIN}" -rjson -e '
     workflow = JSON.parse(STDIN.read)
+    abort("release workflow name mismatch") unless workflow["name"] == "Release"
     abort("release workflow path mismatch") unless workflow["path"] == ".github/workflows/release.yml"
     abort("release workflow is not active") unless workflow["state"] == "active"
     id = workflow["id"]
@@ -1347,7 +1348,7 @@ for ((attempt = 1; attempt <= 30; attempt++)); do
     signed_actor = JSON.parse(File.read(evidence_path)).fetch("authenticatedActor")
     abort("release run ID mismatch") unless run["id"] == run_id.to_i
     abort("release workflow ID mismatch") unless run["workflow_id"] == workflow_id.to_i
-    abort("release workflow name mismatch") unless run["name"] == "Release"
+    abort("release run name mismatch") unless run["name"] == "Release #{tag}"
     abort("release workflow path mismatch") unless run["path"] == ".github/workflows/release.yml"
     abort("release run title mismatch") unless run["display_title"] == "Release #{tag}"
     abort("release run event mismatch") unless run["event"] == "push"


### PR DESCRIPTION
## Summary

- run the protected release-environment checker from the exact trusted tagged Git worktree
- validate GitHub's static workflow name separately from the dynamic `Release vX.Y.Z` run name
- require every unpromoted replacement candidate to increase both SemVer and build
- derive provenance fixture identities ahead of the trusted base candidate
- add fail-closed regression coverage for all three release integration boundaries

## Why

The sole permitted v1.4.0 Release run passed the unsigned candidate job, then stopped before signing at the environment-evidence check because it was invoked from the non-worktree workspace root. The local one-shot helper also falsely rejected the exact run because GitHub exposes the run name as `Release v1.4.0`, while the workflow endpoint retains the static name `Release`.

The recovery audit then found that candidate continuity did not mechanically require the retired v1.4.0/build 8 candidate to roll forward. The new state machine permits first-candidate creation and unchanged candidates, requires strict version/build increases for replacements, and permits candidate clearing only through the existing trusted promotion path. Provenance fixtures now derive their synthetic identity from that trusted base instead of assuming an obsolete fixed version.

v1.4.0 remains permanently retired and will not be rerun, moved, deleted, or reused. This tooling-only PR is the prerequisite for a fresh exact-four-file v1.4.1/build 9 release-prep change.

## Verification

- `git diff --check`
- Bash and Ruby syntax checks
- `scripts/run-actionlint.sh`
- `ruby scripts/check-workflow-contract.rb`
- `ruby Tests/Ruby/WorkflowContractTests.rb` (53 runs, 313 assertions)
- `swift test --scratch-path "$PWD/.build" --filter ReleaseEnvironmentScriptTests` (33 tests)
- `swift test --scratch-path "$PWD/.build" --filter ReleasePushDispatchScriptTests` (16 tests)
- `swift test --scratch-path "$PWD/.build" --filter ReleaseManifestScriptTests` (69 tests)
- `swift test --scratch-path "$PWD/.build" --filter ReleaseProvenanceScriptTests` (16 tests)
- independent read-only reviews: no blockers
