### PR TITLE
Make release assertions promotion-neutral

### DIFF
--- a/Tests/ViftyCoreTests/DocumentationTrustSurfaceTests.swift
+++ b/Tests/ViftyCoreTests/DocumentationTrustSurfaceTests.swift
@@ -184,17 +184,24 @@ final class DocumentationTrustSurfaceTests: XCTestCase {
     }
 
     func testAgentInstructionsTrackCurrentReleaseBoundary() throws {
+        let manifest = try releaseManifest()
+        let published = try XCTUnwrap(manifest["publishedRelease"] as? [String: Any])
+        let publishedTag = try XCTUnwrap(published["tag"] as? String)
         let agents = try read("AGENTS.md")
 
         XCTAssertTrue(agents.contains("`v1.1.1` remains the immutable source-first hotfix and `v1.1.0` is superseded"))
-        XCTAssertTrue(agents.contains("`v1.3.2` is the published Developer ID release; its exact public artifact"))
+        XCTAssertTrue(agents.contains("`\(publishedTag)` is the published Developer ID release; its exact public artifact"))
         XCTAssertTrue(agents.contains("notarization, stapling, TeamID, and Gatekeeper checks passed"))
-        XCTAssertTrue(agents.contains("Signed-helper parity, installed release-mode review, explicit Auto restoration, and manual Fixed/Curve hardware compatibility remain separate claims for the exact `v1.3.2` binary"))
+        XCTAssertTrue(agents.contains("Signed-helper parity, installed release-mode review, explicit Auto restoration, and manual Fixed/Curve hardware compatibility remain separate claims for the exact `\(publishedTag)` binary"))
         XCTAssertTrue(agents.contains("Trusted binary releases use `.github/workflows/release.yml`"))
         XCTAssertFalse(agents.contains("`v1.1.0` is source-first because Apple Developer Program credentials are unavailable"))
     }
 
     func testSupportTriageGuideCoversEvidenceBuckets() throws {
+        let manifest = try releaseManifest()
+        let published = try XCTUnwrap(manifest["publishedRelease"] as? [String: Any])
+        let publishedVersion = try XCTUnwrap(published["version"] as? String)
+        let publishedTag = try XCTUnwrap(published["tag"] as? String)
         let agentCoolingTemplate = try read(".github/ISSUE_TEMPLATE/agent-cooling.yml")
         let releaseTrustTemplate = try read(".github/ISSUE_TEMPLATE/release-trust.yml")
         let contributing = try read("CONTRIBUTING.md")
@@ -259,7 +266,11 @@ final class DocumentationTrustSurfaceTests: XCTestCase {
         XCTAssertTrue(releaseTrustTemplate.contains("name: Release Trust Report"))
         XCTAssertTrue(releaseTrustTemplate.contains("labels: [\"release-trust\"]"))
         XCTAssertTrue(releaseTrustTemplate.contains("scripts/check-release-readiness.sh --mode source-first --version 1.1.1 --repo Reedtrullz/Vifty --json"))
-        XCTAssertTrue(releaseTrustTemplate.contains("scripts/check-release-readiness.sh --mode developer-id --version 1.3.2 --repo Reedtrullz/Vifty --require-source-ref v1.3.2 --json"))
+        XCTAssertTrue(
+            releaseTrustTemplate.contains(
+                "scripts/check-release-readiness.sh --mode developer-id --version \(publishedVersion) --repo Reedtrullz/Vifty --require-source-ref \(publishedTag) --json"
+            )
+        )
         XCTAssertTrue(releaseTrustTemplate.contains("after publication, prefer the immutable tag or release commit SHA"))
         XCTAssertTrue(releaseTrustTemplate.contains("Vifty-v<version>-unsigned-dev.zip"))
         XCTAssertTrue(releaseTrustTemplate.contains("Unsigned-dev checksum missing or mismatched"))
@@ -452,30 +463,76 @@ final class DocumentationTrustSurfaceTests: XCTestCase {
     }
 
     func testReleaseStatusKeepsHomebrewInstallClaimsHonest() throws {
-        let manifestData = try Data(
-            contentsOf: URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
-                .appendingPathComponent(".github/release-manifest.json")
-        )
-        let manifest = try XCTUnwrap(JSONSerialization.jsonObject(with: manifestData) as? [String: Any])
+        let manifest = try releaseManifest()
         let published = try XCTUnwrap(manifest["publishedRelease"] as? [String: Any])
         let publishedVersion = try XCTUnwrap(published["version"] as? String)
         let publishedTag = try XCTUnwrap(published["tag"] as? String)
         let publishedBuild = try XCTUnwrap(published["build"] as? Int)
         let publishedSHA = try XCTUnwrap(published["sha256"] as? String)
         let publishedArtifact = try XCTUnwrap(published["artifact"] as? String)
+        let publishedChecksumAsset = try XCTUnwrap(published["checksumAsset"] as? String)
+        let publishedArtifactTrust = try XCTUnwrap(published["artifactTrust"] as? String)
+        let publishedSigningTrust = try XCTUnwrap(published["signingTrust"] as? String)
+        let publishedTagTrust = try XCTUnwrap(published["tagTrust"] as? String)
+        let publishedSourceCommit = try XCTUnwrap(published["sourceCommit"] as? String)
+        let publishedSourceCIRunID = try XCTUnwrap(published["sourceCIRunID"] as? Int)
+        let publishedReleaseWorkflowRunID = try XCTUnwrap(published["releaseWorkflowRunID"] as? Int)
+        let publishedInstalledReview = try XCTUnwrap(published["installedReleaseReview"] as? String)
+        let publishedManualCompatibility = try XCTUnwrap(published["manualCompatibility"] as? String)
+        let releasePolicy = try XCTUnwrap(manifest["releasePolicy"] as? [String: Any])
+        let developerTeamID = try XCTUnwrap(releasePolicy["developerTeamID"] as? String)
+        let signedTagsRequiredFromVersion = try XCTUnwrap(releasePolicy["signedTagsRequiredFromVersion"] as? String)
         let candidate = manifest["candidate"] as? [String: Any]
+        let allReleaseEntries =
+            (manifest["historicalReleases"] as? [[String: Any]] ?? []) + [published]
+        let immutableV132 = try XCTUnwrap(
+            allReleaseEntries.first { ($0["version"] as? String) == "1.3.2" },
+            "The immutable v1.3.2 publication record must remain present after later promotions."
+        )
         let readme = try read("README.md")
         let releaseStatus = try read("docs/release-status.md")
         let release = try read("docs/release.md")
+        let autoUpdate = try read("docs/auto-update.md")
         let uiReview = try read("docs/ui-review/README.md")
         let cask = try read("Casks/vifty.rb")
         let sourceFirstNotes = try read("docs/release-notes/v1.1.0.md")
         let hotfixNotes = try read("docs/release-notes/v1.1.1.md")
         let unsignedDigestBoundary = "The unsigned-dev zip is valid only with its `.sha256` sidecar, and the SHA-256 digest in that sidecar must match the zip bytes."
 
+        XCTAssertEqual(immutableV132["build"] as? Int, 7)
+        XCTAssertEqual(immutableV132["tag"] as? String, "v1.3.2")
+        XCTAssertEqual(immutableV132["sourceCommit"] as? String, "6a771c2ea10386bf7a0a8369a759930f01d56062")
+        XCTAssertEqual(immutableV132["sourceCIRunID"] as? Int, 29_284_751_837)
+        XCTAssertEqual(immutableV132["releaseWorkflowRunID"] as? Int, 29_285_576_026)
+        XCTAssertEqual(immutableV132["artifact"] as? String, "Vifty-v1.3.2.zip")
+        XCTAssertEqual(immutableV132["sha256"] as? String, "8bbc48b7db7bbe342a6c053a58aa655c969d9b803794f981a4cd8e7d3514bcc0")
+        XCTAssertEqual(immutableV132["artifactTrust"] as? String, "passed")
+        XCTAssertEqual(immutableV132["signingTrust"] as? String, "developer-id-notarized")
+        XCTAssertEqual(immutableV132["installedReleaseReview"] as? String, "passed")
+        XCTAssertEqual(immutableV132["manualCompatibility"] as? String, "passed-auto-restored")
+
         XCTAssertTrue(cask.contains("version \"\(publishedVersion)\""))
         XCTAssertTrue(cask.contains("sha256 \"\(publishedSHA)\""))
         XCTAssertFalse(cask.contains("disable!"))
+        for document in [readme, releaseStatus, release, autoUpdate] {
+            XCTAssertTrue(document.contains("> Published: `\(publishedTag)` (version `\(publishedVersion)`, build `\(publishedBuild)`),"))
+            XCTAssertTrue(document.contains("> Canonical artifact: `\(publishedArtifact)` with checksum asset `\(publishedChecksumAsset)` and SHA-256 `\(publishedSHA)`."))
+            XCTAssertTrue(
+                document.contains(
+                    "> Public artifact trust: `\(publishedArtifactTrust)` / `\(publishedSigningTrust)` for TeamID `\(developerTeamID)`; source `\(publishedSourceCommit)`, CI run `\(publishedSourceCIRunID)`, Release run `\(publishedReleaseWorkflowRunID)`."
+                )
+            )
+            XCTAssertTrue(
+                document.contains(
+                    "> Tag policy: `\(publishedTag)` remains recorded as `\(publishedTagTrust)` evidence; signed tags are mandatory from version `\(signedTagsRequiredFromVersion)` onward."
+                )
+            )
+            XCTAssertTrue(document.contains("> Separate exact-build claims: installed release review `\(publishedInstalledReview)`; manual Fixed/Curve/Auto compatibility `\(publishedManualCompatibility)`"))
+        }
+        XCTAssertTrue(readme.contains("The lane begins with `v1.4.0`"))
+        XCTAssertTrue(autoUpdate.contains("starts with `v1.4.0`"))
+        XCTAssertTrue(release.contains("The bridge starts at `v1.4.0`"))
+        XCTAssertTrue(releaseStatus.contains("for promoted `v1.4.0` and newer releases"))
         XCTAssertTrue(readme.contains("Vifty `\(publishedTag)` is the current published Developer ID release."))
         XCTAssertTrue(readme.contains("`v1.1.1` remains the published source-first fallback"))
         XCTAssertTrue(readme.contains("**Three fan modes** — Auto, Fixed RPM with optional percentage-aware per-fan targets, and a 3-point Temperature Curve."))
@@ -501,7 +558,7 @@ final class DocumentationTrustSurfaceTests: XCTestCase {
         XCTAssertTrue(uiReview.contains("not current-source UI evidence"))
         XCTAssertTrue(uiReview.contains("not the full evidence bundle, a human visual or VoiceOver attestation"))
         XCTAssertFalse(uiReview.contains("no portable automated checkpoint exists yet"))
-        XCTAssertTrue(readme.contains("The exact installed public `\(publishedTag)` build also passed release-mode review and human-supervised Fixed → Auto → Curve → Auto validation on `MacBookPro18,1`"))
+        XCTAssertTrue(readme.contains("The exact installed public `v1.3.2` build also passed release-mode review and human-supervised Fixed → Auto → Curve → Auto validation on `MacBookPro18,1`"))
         XCTAssertTrue(readme.contains("Installed-binary parity, explicit Auto restoration, and manual hardware compatibility are now separately reviewed for that exact build on `MacBookPro18,1`"))
         XCTAssertFalse(readme.contains("brew install --cask vifty"))
         XCTAssertTrue(release.contains("[release-status.md](release-status.md)"))
@@ -593,12 +650,12 @@ final class DocumentationTrustSurfaceTests: XCTestCase {
         )
         XCTAssertTrue(releaseStatus.contains("`\(publishedTag)` is the current published Developer ID release."))
         XCTAssertTrue(releaseStatus.contains("`v1.1.1` remains the published source-first fallback; its immutable tag resolves to `a82f2237ff39c24a6b366dca8f95a17ee54fd972`."))
-        XCTAssertTrue(releaseStatus.contains("Developer ID publication evidence for immutable `\(publishedTag)`: at publication time"))
+        XCTAssertTrue(releaseStatus.contains("Developer ID publication evidence for immutable `v1.3.2`: at publication time"))
         XCTAssertTrue(releaseStatus.contains("The published workflow summary and prior independent downloaded-artifact verification record passes for the exact public zip and cask."))
         XCTAssertTrue(releaseStatus.contains("The public `\(publishedArtifact)` and checked-in cask both resolve to SHA-256 `\(publishedSHA)`"))
         XCTAssertTrue(releaseStatus.contains("Do not use another organization's team or certificate for Vifty."))
         XCTAssertTrue(releaseStatus.contains("Published Developer ID release:** `\(publishedTag)` public artifact and cask trust checks passed"))
-        XCTAssertTrue(releaseStatus.contains("The exact installed public `\(publishedTag)` build `\(publishedBuild)` passed release-mode review on `MacBookPro18,1`."))
+        XCTAssertTrue(releaseStatus.contains("The exact installed public `v1.3.2` build `7` passed release-mode review on `MacBookPro18,1`."))
         XCTAssertTrue(releaseStatus.contains("validation-reports/2026-07-14-v1.3.2-macbookpro18-release/review-result.json"))
         XCTAssertTrue(releaseStatus.contains("The separate supported-hardware review also passed with `manualSmokeTestResult: \"passed-auto-restored\"`."))
         XCTAssertTrue(releaseStatus.contains("active GitHub ruleset `18940029` (`Immutable Vifty release tags`)"))
@@ -650,6 +707,54 @@ final class DocumentationTrustSurfaceTests: XCTestCase {
                     "The manifest candidate remains `null` until a separate release-prep pull request passes exact-main CI"
                 )
             )
+        }
+        if publishedInstalledReview == "passed" {
+            XCTAssertTrue(
+                releaseStatus.contains(
+                    "The exact installed public `\(publishedTag)` build `\(publishedBuild)` passed release-mode review"
+                )
+            )
+        } else {
+            XCTAssertEqual(publishedInstalledReview, "pending")
+            XCTAssertFalse(
+                releaseStatus.contains(
+                    "The exact installed public `\(publishedTag)` build `\(publishedBuild)` passed release-mode review"
+                ),
+                "A newly promoted release must not inherit the prior binary's installed-review claim."
+            )
+        }
+        if publishedManualCompatibility == "passed-auto-restored" {
+            let scope = try XCTUnwrap(published["manualCompatibilityScope"] as? [String: Any])
+            let models = try XCTUnwrap(scope["modelIdentifiers"] as? [String])
+            let reviewReport = try XCTUnwrap(scope["reviewReport"] as? String)
+            let attestation = try XCTUnwrap(scope["attestation"] as? String)
+            for model in models {
+                XCTAssertTrue(releaseStatus.contains("`\(model)`"))
+            }
+            XCTAssertTrue(releaseStatus.contains(reviewReport))
+            XCTAssertTrue(releaseStatus.contains(attestation))
+        } else {
+            XCTAssertEqual(publishedManualCompatibility, "pending")
+            XCTAssertNil(published["manualCompatibilityScope"] as? [String: Any])
+            XCTAssertFalse(
+                releaseStatus.contains(
+                    "manual Fixed/Curve compatibility also passed as separately reviewed claims for exact build \(publishedBuild)"
+                ),
+                "A newly promoted release must not inherit prior-version supervised hardware evidence."
+            )
+        }
+
+        let newestManifestVersion = try XCTUnwrap(
+            candidate?["version"] as? String ?? published["version"] as? String
+        )
+        if isVersion(newestManifestVersion, atLeast: "1.4.1") {
+            XCTAssertTrue(releaseStatus.contains("`v1.4.0`"))
+            XCTAssertTrue(releaseStatus.lowercased().contains("retired without publication"))
+            XCTAssertTrue(releaseStatus.contains("29658220561"))
+            XCTAssertTrue(releaseStatus.contains("08259da0ad43b720938246848a5dae3bfc2221e0"))
+            XCTAssertTrue(releaseStatus.contains("8b39f8701ec3ea3d3e946de335f7cf95ee0b1908"))
+            XCTAssertTrue(releaseStatus.contains("Do not rerun"))
+            XCTAssertTrue(releaseStatus.contains("delete, move, or reuse"))
         }
         XCTAssertTrue(releaseStatus.contains(publishedSHA))
         XCTAssertTrue(releaseStatus.contains("`v1.1.1` remains the published source-first fallback."))
@@ -996,14 +1101,42 @@ final class DocumentationTrustSurfaceTests: XCTestCase {
     }
 
     func testAutoUpdateDocsKeepSourceFirstBuildsOutOfSelfUpdatingLane() throws {
+        let manifest = try releaseManifest()
+        let published = try XCTUnwrap(manifest["publishedRelease"] as? [String: Any])
+        let publishedVersion = try XCTUnwrap(published["version"] as? String)
+        let publishedTag = try XCTUnwrap(published["tag"] as? String)
+        let publishedContainsAdvisoryChecker = isVersion(publishedVersion, atLeast: "1.4.1")
         let autoUpdate = try read("docs/auto-update.md")
         let readme = try read("README.md")
         let releaseStatus = try read("docs/release-status.md")
 
         XCTAssertTrue(readme.contains("[docs/auto-update.md](docs/auto-update.md)"))
         XCTAssertTrue(releaseStatus.contains("[auto-update.md](auto-update.md)"))
-        XCTAssertTrue(autoUpdate.contains("Auto-update is not enabled for `v1.3.2`"))
-        XCTAssertTrue(autoUpdate.contains("exact public binary does not contain update checking"))
+        XCTAssertTrue(autoUpdate.contains("Auto-update is not enabled for `\(publishedTag)`"))
+        if publishedContainsAdvisoryChecker {
+            XCTAssertTrue(
+                autoUpdate.contains(
+                    "its exact public binary contains the advisory release-availability checker but no executable downloader or in-place installer"
+                )
+            )
+            XCTAssertTrue(
+                readme.contains(
+                    "The exact public `\(publishedTag)` binary contains the advisory release-availability checker"
+                )
+            )
+            XCTAssertTrue(
+                releaseStatus.contains(
+                    "Update status: the exact public `\(publishedTag)` binary contains the advisory release-availability checker"
+                )
+            )
+        } else {
+            XCTAssertTrue(autoUpdate.contains("exact public binary does not contain update checking"))
+            XCTAssertTrue(
+                releaseStatus.contains(
+                    "Update status: the exact public `\(publishedTag)` binary has no update checker and cannot gain one retroactively"
+                )
+            )
+        }
         XCTAssertTrue(autoUpdate.contains("other ineligible builds make zero update requests"))
         XCTAssertTrue(autoUpdate.contains("https://api.github.com/repos/Reedtrullz/Vifty/releases/latest"))
         XCTAssertTrue(autoUpdate.contains("exactly four uploaded, nonempty canonical assets"))
@@ -1031,12 +1164,20 @@ final class DocumentationTrustSurfaceTests: XCTestCase {
     }
 
     func testReleaseDocsIncludeFutureAutoUpdateReadinessChecks() throws {
+        let manifest = try releaseManifest()
+        let published = try XCTUnwrap(manifest["publishedRelease"] as? [String: Any])
+        let publishedVersion = try XCTUnwrap(published["version"] as? String)
+        let publishedTag = try XCTUnwrap(published["tag"] as? String)
         let release = try read("docs/release.md")
         let trustModel = try read("docs/trust-model.md")
 
         XCTAssertTrue(release.contains("[auto-update.md](auto-update.md)"))
         XCTAssertTrue(release.contains("Release-availability checking, manual public-archive installation, and future in-place updating are three separate trust lanes"))
-        XCTAssertTrue(release.contains("checker is absent from the current `v1.3.2` artifact"))
+        if isVersion(publishedVersion, atLeast: "1.4.1") {
+            XCTAssertTrue(release.contains("checker is present in the current `\(publishedTag)` artifact"))
+        } else {
+            XCTAssertTrue(release.contains("checker is absent from the current `\(publishedTag)` artifact"))
+        }
         XCTAssertTrue(release.contains("SUFeedURL"))
         XCTAssertTrue(release.contains("SUPublicEDKey"))
         XCTAssertTrue(release.contains("generate_appcast"))
@@ -1926,6 +2067,26 @@ final class DocumentationTrustSurfaceTests: XCTestCase {
         XCTAssertFalse(workplan.contains("439 XCTest cases"))
         XCTAssertFalse(workplan.contains("401 XCTest cases"))
         XCTAssertFalse(workplan.contains("Review the full dirty tree"))
+    }
+
+    private func releaseManifest() throws -> [String: Any] {
+        let data = try Data(
+            contentsOf: URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+                .appendingPathComponent(".github/release-manifest.json")
+        )
+        return try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+    }
+
+    private func isVersion(_ version: String, atLeast minimum: String) -> Bool {
+        let versionComponents = version.split(separator: ".").compactMap { Int($0) }
+        let minimumComponents = minimum.split(separator: ".").compactMap { Int($0) }
+        guard versionComponents.count == 3, minimumComponents.count == 3 else {
+            return false
+        }
+        for index in 0..<3 where versionComponents[index] != minimumComponents[index] {
+            return versionComponents[index] > minimumComponents[index]
+        }
+        return true
     }
 
     private func read(_ relativePath: String) throws -> String {

--- a/Tests/ViftyCoreTests/ReleaseManifestScriptTests.swift
+++ b/Tests/ViftyCoreTests/ReleaseManifestScriptTests.swift
@@ -16,7 +16,7 @@ final class ReleaseManifestScriptTests: XCTestCase {
         XCTAssertTrue(result.stdout.contains("Release manifest OK"))
     }
 
-    func testPublishedReleaseFactsRemainHistoricalAndAnyCandidateFailsClosed() throws {
+    func testReleaseManifestPreservesImmutableV132AndCurrentReleaseTrust() throws {
         let manifest = try readJSON(
             repositoryRoot.appendingPathComponent(".github/release-manifest.json")
         )
@@ -32,15 +32,98 @@ final class ReleaseManifestScriptTests: XCTestCase {
         XCTAssertEqual(product["architectures"] as? [String], ["arm64"])
         XCTAssertEqual(policy["developerTeamID"] as? String, "X88J3853S2")
         XCTAssertEqual(policy["signedTagsRequiredFromVersion"] as? String, "1.3.3")
-        XCTAssertTrue(history.isEmpty)
-        XCTAssertEqual(published["version"] as? String, "1.3.2")
-        XCTAssertEqual(published["build"] as? Int, 7)
-        XCTAssertEqual(published["tagTrust"] as? String, "historical-unsigned")
+
+        let publishedVersion = try XCTUnwrap(published["version"] as? String)
+        XCTAssertEqual(published["tag"] as? String, "v\(publishedVersion)")
+        XCTAssertEqual(published["artifact"] as? String, "Vifty-v\(publishedVersion).zip")
+        XCTAssertEqual(
+            published["checksumAsset"] as? String,
+            "Vifty-v\(publishedVersion).zip.sha256"
+        )
+        XCTAssertEqual(
+            published["artifactSummary"] as? String,
+            "Vifty-v\(publishedVersion)-artifact-summary.json"
+        )
+        XCTAssertEqual(
+            published["releaseChecklist"] as? String,
+            "Vifty-v\(publishedVersion)-release-checklist.md"
+        )
+        XCTAssertNotNil(
+            (published["sha256"] as? String)?.range(
+                of: "^[0-9a-f]{64}$",
+                options: .regularExpression
+            )
+        )
+        XCTAssertNotNil(
+            (published["sourceCommit"] as? String)?.range(
+                of: "^[0-9a-f]{40}$",
+                options: .regularExpression
+            )
+        )
+        XCTAssertGreaterThan(try XCTUnwrap(published["sourceCIRunID"] as? Int), 0)
+        XCTAssertGreaterThan(try XCTUnwrap(published["releaseWorkflowRunID"] as? Int), 0)
         XCTAssertEqual(published["artifactTrust"] as? String, "passed")
-        XCTAssertEqual(published["installedReleaseReview"] as? String, "passed")
-        XCTAssertEqual(published["manualCompatibility"] as? String, "passed-auto-restored")
+        XCTAssertEqual(published["signingTrust"] as? String, "developer-id-notarized")
+        XCTAssertEqual(
+            published["tagTrust"] as? String,
+            publishedVersion == "1.3.2" ? "historical-unsigned" : "signed-verified"
+        )
+        let publishedInstalledReleaseReview = try XCTUnwrap(
+            published["installedReleaseReview"] as? String
+        )
+        XCTAssertTrue(["pending", "passed"].contains(publishedInstalledReleaseReview))
+
+        let publishedManualCompatibility = try XCTUnwrap(
+            published["manualCompatibility"] as? String
+        )
+        XCTAssertTrue(["pending", "passed-auto-restored"].contains(publishedManualCompatibility))
+        if publishedManualCompatibility == "pending" {
+            XCTAssertEqual(published["manualCompatibilityScope"] as? NSNull, NSNull())
+        } else {
+            let scope = try XCTUnwrap(published["manualCompatibilityScope"] as? [String: Any])
+            XCTAssertFalse(try XCTUnwrap(scope["modelIdentifiers"] as? [String]).isEmpty)
+            XCTAssertFalse(try XCTUnwrap(scope["reviewReport"] as? String).isEmpty)
+            XCTAssertFalse(try XCTUnwrap(scope["attestation"] as? String).isEmpty)
+        }
+
+        let releases = history + [published]
+        XCTAssertEqual(
+            releases.filter { $0["version"] as? String == "1.3.2" }.count,
+            1,
+            "the immutable v1.3.2 boundary must appear exactly once across history and current"
+        )
+        let immutableV132 = try XCTUnwrap(
+            releases.first { $0["version"] as? String == "1.3.2" }
+        )
+        XCTAssertEqual(immutableV132["build"] as? Int, 7)
+        XCTAssertEqual(immutableV132["tag"] as? String, "v1.3.2")
+        XCTAssertEqual(
+            immutableV132["sourceCommit"] as? String,
+            "6a771c2ea10386bf7a0a8369a759930f01d56062"
+        )
+        XCTAssertEqual(immutableV132["sourceCIRunID"] as? Int, 29284751837)
+        XCTAssertEqual(immutableV132["releaseWorkflowRunID"] as? Int, 29285576026)
+        XCTAssertEqual(immutableV132["artifact"] as? String, "Vifty-v1.3.2.zip")
+        XCTAssertEqual(immutableV132["checksumAsset"] as? String, "Vifty-v1.3.2.zip.sha256")
+        XCTAssertEqual(
+            immutableV132["artifactSummary"] as? String,
+            "Vifty-v1.3.2-artifact-summary.json"
+        )
+        XCTAssertEqual(
+            immutableV132["releaseChecklist"] as? String,
+            "Vifty-v1.3.2-release-checklist.md"
+        )
+        XCTAssertEqual(
+            immutableV132["sha256"] as? String,
+            "8bbc48b7db7bbe342a6c053a58aa655c969d9b803794f981a4cd8e7d3514bcc0"
+        )
+        XCTAssertEqual(immutableV132["artifactTrust"] as? String, "passed")
+        XCTAssertEqual(immutableV132["signingTrust"] as? String, "developer-id-notarized")
+        XCTAssertEqual(immutableV132["tagTrust"] as? String, "historical-unsigned")
+        XCTAssertEqual(immutableV132["installedReleaseReview"] as? String, "passed")
+        XCTAssertEqual(immutableV132["manualCompatibility"] as? String, "passed-auto-restored")
         let compatibilityScope = try XCTUnwrap(
-            published["manualCompatibilityScope"] as? [String: Any]
+            immutableV132["manualCompatibilityScope"] as? [String: Any]
         )
         XCTAssertEqual(
             compatibilityScope["modelIdentifiers"] as? [String],
@@ -526,29 +609,93 @@ final class ReleaseManifestScriptTests: XCTestCase {
         XCTAssertTrue(result.stdout.contains("Release fact blocks OK"))
     }
 
-    func testReleaseFactBlocksScopeManualCompatibilityToValidatedModelAndEvidence() throws {
+    func testReleaseFactBlockReflectsCurrentPublishedReviewAndCompatibilityState() throws {
+        let manifest = try readJSON(
+            repositoryRoot.appendingPathComponent(".github/release-manifest.json")
+        )
+        let published = try XCTUnwrap(manifest["publishedRelease"] as? [String: Any])
         let readme = try String(
             contentsOf: repositoryRoot.appendingPathComponent("README.md"),
             encoding: .utf8
         )
+        let facts = try generatedReleaseFacts(in: readme)
+        let installedReleaseReview = try XCTUnwrap(
+            published["installedReleaseReview"] as? String
+        )
+        let manualCompatibility = try XCTUnwrap(
+            published["manualCompatibility"] as? String
+        )
 
+        let manualCompatibilityFact: String
+        if manualCompatibility == "passed-auto-restored" {
+            let scope = try XCTUnwrap(published["manualCompatibilityScope"] as? [String: Any])
+            let models = try XCTUnwrap(scope["modelIdentifiers"] as? [String])
+            let modelList = models.map { "`\($0)`" }.joined(separator: ", ")
+            manualCompatibilityFact =
+                "manual Fixed/Curve/Auto compatibility `passed-auto-restored` on " +
+                "\(modelList) only (review " +
+                "`\(try XCTUnwrap(scope["reviewReport"] as? String))`; attestation " +
+                "`\(try XCTUnwrap(scope["attestation"] as? String))`)"
+        } else {
+            XCTAssertEqual(manualCompatibility, "pending")
+            XCTAssertEqual(published["manualCompatibilityScope"] as? NSNull, NSNull())
+            manualCompatibilityFact = "manual Fixed/Curve/Auto compatibility `pending`"
+        }
+        let expectedLine =
+            "> Separate exact-build claims: installed release review " +
+            "`\(installedReleaseReview)`; \(manualCompatibilityFact)."
         XCTAssertTrue(
-            readme.contains(
-                "manual Fixed/Curve/Auto compatibility `passed-auto-restored` on `MacBookPro18,1` only"
-            ),
-            readme
+            facts.split(separator: "\n").contains(Substring(expectedLine)),
+            "missing exact generated review line:\n\(expectedLine)\n\n\(facts)"
+        )
+    }
+
+    func testRendererUsesSyntheticV141PublishedPendingFactsWithoutHistoricalScopeLeakage() throws {
+        let fixture = try ReleaseFactsFixture(repositoryRoot: repositoryRoot)
+
+        let result = try fixture.render()
+
+        XCTAssertEqual(result.exitCode, 0, result.stderr)
+        XCTAssertTrue(result.stdout.contains("Updated generated release fact blocks"), result.stdout)
+        let generatedFactsByPath = try fixture.generatedReleaseFactsByPath()
+        let expectedFacts = try XCTUnwrap(generatedFactsByPath["README.md"])
+        for (relativePath, facts) in generatedFactsByPath {
+            XCTAssertEqual(facts, expectedFacts, "generated facts differ in \(relativePath)")
+        }
+        XCTAssertTrue(
+            expectedFacts.contains("Published: `v1.4.1` (version `1.4.1`, build `9`)"),
+            expectedFacts
         )
         XCTAssertTrue(
-            readme.contains(
-                "review `docs/validation-reports/2026-07-14-v1.3.2-macbookpro18-supported/review-result.json`"
+            expectedFacts.contains(
+                "Canonical artifact: `Vifty-v1.4.1.zip` with checksum asset " +
+                "`Vifty-v1.4.1.zip.sha256` and SHA-256 `\(String(repeating: "e", count: 64))`."
             ),
-            readme
+            expectedFacts
         )
         XCTAssertTrue(
-            readme.contains(
-                "attestation `docs/validation-reports/2026-07-14-v1.3.2-macbookpro18-supported/manual-smoke-attestation.md`"
+            expectedFacts.contains(
+                "Public artifact trust: `passed` / `developer-id-notarized` for TeamID " +
+                "`X88J3853S2`; source `\(String(repeating: "d", count: 40))`, " +
+                "CI run `30000001`, Release run `30000002`."
             ),
-            readme
+            expectedFacts
+        )
+        XCTAssertTrue(
+            expectedFacts.contains("Tag policy: `v1.4.1` remains recorded as `signed-verified` evidence"),
+            expectedFacts
+        )
+        XCTAssertTrue(
+            expectedFacts.contains(
+                "installed release review `pending`; manual Fixed/Curve/Auto compatibility `pending`"
+            ),
+            expectedFacts
+        )
+        XCTAssertFalse(expectedFacts.contains("passed-auto-restored"), expectedFacts)
+        XCTAssertFalse(expectedFacts.contains("MacBookPro18,1"), expectedFacts)
+        XCTAssertFalse(
+            expectedFacts.contains("2026-07-14-v1.3.2-macbookpro18-supported"),
+            expectedFacts
         )
     }
 
@@ -1436,6 +1583,200 @@ final class ReleaseManifestScriptTests: XCTestCase {
             stderr: String(decoding: stderr.fileHandleForReading.readDataToEndOfFile(), as: UTF8.self),
             exitCode: process.terminationStatus
         )
+    }
+}
+
+private let generatedReleaseFactsStartMarker = "<!-- BEGIN GENERATED RELEASE FACTS -->"
+private let generatedReleaseFactsEndMarker = "<!-- END GENERATED RELEASE FACTS -->"
+
+private func generatedReleaseFacts(in text: String) throws -> String {
+    let start = try XCTUnwrap(text.range(of: generatedReleaseFactsStartMarker))
+    let end = try XCTUnwrap(
+        text.range(
+            of: generatedReleaseFactsEndMarker,
+            range: start.upperBound..<text.endIndex
+        )
+    )
+    XCTAssertNil(
+        text.range(
+            of: generatedReleaseFactsStartMarker,
+            range: start.upperBound..<text.endIndex
+        ),
+        "generated release facts must contain exactly one start marker"
+    )
+    XCTAssertNil(
+        text.range(
+            of: generatedReleaseFactsEndMarker,
+            range: end.upperBound..<text.endIndex
+        ),
+        "generated release facts must contain exactly one end marker"
+    )
+    return String(text[start.lowerBound..<end.upperBound])
+}
+
+private final class ReleaseFactsFixture {
+    private static let renderedDocumentationPaths = [
+        "README.md",
+        "SECURITY.md",
+        "SUPPORT.md",
+        "docs/release-status.md",
+        "docs/trust-model.md",
+        "docs/competitive-analysis.md",
+        "docs/compatibility.md",
+        "docs/release.md",
+        "docs/auto-update.md"
+    ]
+
+    let rootURL: URL
+    private let repositoryRoot: URL
+
+    init(repositoryRoot: URL) throws {
+        self.repositoryRoot = repositoryRoot
+        rootURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("vifty-release-facts-\(UUID().uuidString)", isDirectory: true)
+
+        let fixturePaths = [
+            ".github/release-manifest.json",
+            "docs/schemas/release-manifest.schema.json",
+            "Resources/Info.plist",
+            "Resources/tech.reidar.vifty.daemon.plist",
+            "Casks/vifty.rb",
+            "Package.swift"
+        ] + Self.renderedDocumentationPaths
+        for relativePath in fixturePaths {
+            let destination = rootURL.appendingPathComponent(relativePath)
+            try FileManager.default.createDirectory(
+                at: destination.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+            try FileManager.default.copyItem(
+                at: repositoryRoot.appendingPathComponent(relativePath),
+                to: destination
+            )
+        }
+
+        try writeSyntheticPublishedManifest()
+        try writeSyntheticInfoPlist()
+        try writeSyntheticCask()
+    }
+
+    deinit {
+        try? FileManager.default.removeItem(at: rootURL)
+    }
+
+    func render() throws -> ReleaseManifestProcessResult {
+        let process = Process()
+        process.executableURL = repositoryRoot.appendingPathComponent("scripts/render-release-facts.sh")
+        process.arguments = ["--write"]
+        process.environment = ProcessInfo.processInfo.environment.merging(
+            ["VIFTY_RELEASE_FACTS_ROOT": rootURL.path],
+            uniquingKeysWith: { _, new in new }
+        )
+        let stdout = Pipe()
+        let stderr = Pipe()
+        process.standardOutput = stdout
+        process.standardError = stderr
+        try process.run()
+        process.waitUntilExit()
+        return ReleaseManifestProcessResult(
+            stdout: String(decoding: stdout.fileHandleForReading.readDataToEndOfFile(), as: UTF8.self),
+            stderr: String(decoding: stderr.fileHandleForReading.readDataToEndOfFile(), as: UTF8.self),
+            exitCode: process.terminationStatus
+        )
+    }
+
+    func generatedReleaseFactsByPath() throws -> [String: String] {
+        try Dictionary(uniqueKeysWithValues: Self.renderedDocumentationPaths.map { relativePath in
+            let text = try String(
+                contentsOf: rootURL.appendingPathComponent(relativePath),
+                encoding: .utf8
+            )
+            return (relativePath, try generatedReleaseFacts(in: text))
+        })
+    }
+
+    private func writeSyntheticPublishedManifest() throws {
+        let manifestURL = rootURL.appendingPathComponent(".github/release-manifest.json")
+        var manifest = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: Data(contentsOf: manifestURL)) as? [String: Any]
+        )
+        let currentPublished = try XCTUnwrap(
+            manifest["publishedRelease"] as? [String: Any]
+        )
+        let historical = try XCTUnwrap(
+            manifest["historicalReleases"] as? [[String: Any]]
+        )
+        let immutableV132 = try XCTUnwrap(
+            (historical + [currentPublished]).first { $0["version"] as? String == "1.3.2" },
+            "renderer fixture requires the immutable v1.3.2 release boundary"
+        )
+        var syntheticPublished = immutableV132
+        syntheticPublished["version"] = "1.4.1"
+        syntheticPublished["build"] = 9
+        syntheticPublished["tag"] = "v1.4.1"
+        syntheticPublished["sourceCommit"] = String(repeating: "d", count: 40)
+        syntheticPublished["sourceCIRunID"] = 30_000_001
+        syntheticPublished["releaseWorkflowRunID"] = 30_000_002
+        syntheticPublished["artifact"] = "Vifty-v1.4.1.zip"
+        syntheticPublished["checksumAsset"] = "Vifty-v1.4.1.zip.sha256"
+        syntheticPublished["artifactSummary"] = "Vifty-v1.4.1-artifact-summary.json"
+        syntheticPublished["releaseChecklist"] = "Vifty-v1.4.1-release-checklist.md"
+        syntheticPublished["sha256"] = String(repeating: "e", count: 64)
+        syntheticPublished["artifactTrust"] = "passed"
+        syntheticPublished["signingTrust"] = "developer-id-notarized"
+        syntheticPublished["tagTrust"] = "signed-verified"
+        syntheticPublished["installedReleaseReview"] = "pending"
+        syntheticPublished["manualCompatibility"] = "pending"
+        syntheticPublished["manualCompatibilityScope"] = NSNull()
+
+        manifest["historicalReleases"] = [immutableV132]
+        manifest["publishedRelease"] = syntheticPublished
+        manifest["candidate"] = NSNull()
+        let data = try JSONSerialization.data(
+            withJSONObject: manifest,
+            options: [.prettyPrinted, .sortedKeys]
+        )
+        try data.write(to: manifestURL)
+    }
+
+    private func writeSyntheticInfoPlist() throws {
+        let plistURL = rootURL.appendingPathComponent("Resources/Info.plist")
+        var format = PropertyListSerialization.PropertyListFormat.xml
+        var plist = try XCTUnwrap(
+            PropertyListSerialization.propertyList(
+                from: Data(contentsOf: plistURL),
+                options: [],
+                format: &format
+            ) as? [String: Any]
+        )
+        plist["CFBundleShortVersionString"] = "1.4.1"
+        plist["CFBundleVersion"] = "9"
+        let data = try PropertyListSerialization.data(
+            fromPropertyList: plist,
+            format: .xml,
+            options: 0
+        )
+        try data.write(to: plistURL)
+    }
+
+    private func writeSyntheticCask() throws {
+        let caskURL = rootURL.appendingPathComponent("Casks/vifty.rb")
+        let cask = try String(contentsOf: caskURL, encoding: .utf8)
+        let versionPattern = #"version "[^"]+""#
+        let checksumPattern = #"sha256 "[0-9a-f]{64}""#
+        XCTAssertNotNil(cask.range(of: versionPattern, options: .regularExpression))
+        XCTAssertNotNil(cask.range(of: checksumPattern, options: .regularExpression))
+        let versioned = cask.replacingOccurrences(
+            of: versionPattern,
+            with: #"version "1.4.1""#,
+            options: .regularExpression
+        )
+        let updated = versioned.replacingOccurrences(
+            of: checksumPattern,
+            with: "sha256 \"\(String(repeating: "e", count: 64))\"",
+            options: .regularExpression
+        )
+        try updated.write(to: caskURL, atomically: true, encoding: .utf8)
     }
 }
 


### PR DESCRIPTION
## Summary\n\n- keep immutable v1.3.2 publication and hardware evidence explicitly historical\n- make current release assertions follow the manifest without inheriting prior installed or manual compatibility claims\n- add a bounded synthetic v1.4.1 build 9 published-pending renderer fixture\n- reject duplicate generated release-fact markers and stale current-release prose\n\n## Verification\n\n- RELEASE_METADATA_MODE=developer-id make verify-full\n- 1,983 Swift tests passed\n- warnings-as-errors build, release app bundle, plist and code-sign checks passed\n- Ruby schema, inventory, workflow, installer, lifecycle, and UI evidence contract suites passed\n\n## Release boundary\n\nThis PR changes tests only. It must land before the exact four-file v1.4.1 release-prep commit.