### PR TITLE
Harden release draft ownership and containment verification

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1291,6 +1291,8 @@ jobs:
             local destination="$1"
             local pages_path="${destination}.pages"
             release_gh api --hostname github.com --paginate --slurp \
+              -H 'Cache-Control: no-cache' \
+              -H 'Pragma: no-cache' \
               "repos/${GITHUB_REPOSITORY}/releases?per_page=100" \
               > "${pages_path}" || return 1
             ruby -rjson -e '
@@ -1309,6 +1311,27 @@ jobs:
             release_gh api --hostname github.com "repos/${GITHUB_REPOSITORY}/releases/${release_id}" > "${destination}"
           }
 
+          capture_created_release_id() {
+            local state_path="$1"
+            ruby -rjson -e '
+              release = JSON.parse(File.read(ARGV.fetch(0)))
+              repository = ARGV.fetch(1)
+              tag = ARGV.fetch(2)
+              id = release["id"]
+              api_base = id.is_a?(Integer) && id.positive? ?
+                "https://api.github.com/repos/#{repository}/releases/#{id}" : nil
+              upload_url = id.is_a?(Integer) && id.positive? ?
+                "https://uploads.github.com/repos/#{repository}/releases/#{id}/assets{?name,label}" : nil
+              valid = id.is_a?(Integer) && id.positive? &&
+                release["url"] == api_base &&
+                release["assets_url"] == "#{api_base}/assets" &&
+                release["upload_url"] == upload_url &&
+                release["tag_name"] == tag
+              abort("creation response does not prove immutable repository-scoped ID/tag identity") unless valid
+              print id
+            ' "${state_path}" "${GITHUB_REPOSITORY}" "${RELEASE_TAG}"
+          }
+
           capture_owned_draft_release_id() {
             local state_path="$1"
             ruby -rjson -e '
@@ -1317,7 +1340,7 @@ jobs:
               marker = ARGV.fetch(3)
               body = release["body"]
               marker_valid = body.is_a?(String) &&
-                body.scan(Regexp.escape(marker)).length == 1 &&
+                body.scan(marker).length == 1 &&
                 body.lines.map(&:strip).include?(marker)
               valid = id.is_a?(Integer) && id.positive? &&
                 release["tag_name"] == ARGV.fetch(1) &&
@@ -1330,17 +1353,41 @@ jobs:
             ' "${state_path}" "${RELEASE_TAG}" "${DRAFT_TITLE}" "${RELEASE_MARKER}"
           }
 
-          discover_owned_draft_by_tag() {
+          discover_owned_release_by_tag_for_containment() {
             local destination="$1"
             if query_release_by_tag "${destination}"; then
-              if ! capture_owned_draft_release_id "${destination}" > /dev/null; then
-                echo "The by-tag release does not carry this run's exact draft title and ownership marker; refusing mutation." >&2
+              local discovered_release_id
+              if ! discovered_release_id="$(capture_created_release_id "${destination}")" ||
+                 ! verify_release_owned_for_containment "${destination}" "${discovered_release_id}"; then
+                echo "The by-tag release does not carry this run's exact repository-scoped ID, title, and ownership marker; refusing mutation." >&2
                 return 5
               fi
               return 0
             else
               return $?
             fi
+          }
+
+          wait_for_owned_release_by_tag_for_containment() {
+            local destination="$1"
+            local deadline=$((SECONDS + 60))
+            local discovery_status
+
+            while true; do
+              if discover_owned_release_by_tag_for_containment "${destination}"; then
+                return 0
+              else
+                discovery_status=$?
+              fi
+              if [[ "${discovery_status}" -ne 3 ]]; then
+                return 1
+              fi
+              if (( SECONDS >= deadline )); then
+                echo "Containment could not prove post-creation absence or exact marker ownership for ${RELEASE_TAG} within 60 seconds." >&2
+                return 1
+              fi
+              /bin/sleep 2
+            done
           }
 
           verify_release_state() {
@@ -1432,7 +1479,7 @@ jobs:
               marker = ARGV.fetch(3)
               body = release["body"]
               marker_valid = body.is_a?(String) &&
-                body.scan(Regexp.escape(marker)).length == 1 &&
+                body.scan(marker).length == 1 &&
                 body.lines.map(&:strip).include?(marker)
               valid = release["id"] == Integer(ARGV.fetch(1), 10) &&
                 release["tag_name"] == ARGV.fetch(2) &&
@@ -1485,7 +1532,7 @@ jobs:
               marker = ARGV.fetch(3)
               body = release["body"]
               marker_valid = body.is_a?(String) &&
-                body.scan(Regexp.escape(marker)).length == 1 &&
+                body.scan(marker).length == 1 &&
                 body.lines.map(&:strip).include?(marker)
               valid = release["id"] == Integer(ARGV.fetch(1), 10) &&
                 release["tag_name"] == ARGV.fetch(2) &&
@@ -1504,7 +1551,7 @@ jobs:
               marker = ARGV.fetch(3)
               body = release["body"]
               marker_valid = body.is_a?(String) &&
-                body.scan(Regexp.escape(marker)).length == 1 &&
+                body.scan(marker).length == 1 &&
                 body.lines.map(&:strip).include?(marker)
               valid = release["id"] == Integer(ARGV.fetch(1), 10) &&
                 release["tag_name"] == ARGV.fetch(2) &&
@@ -1514,6 +1561,34 @@ jobs:
               abort("release containment ownership/draft readback failed") unless valid
             ' "${state_path}" "${release_id}" "${RELEASE_TAG}" "${RELEASE_MARKER}" \
               "${DRAFT_TITLE}" "${FINAL_TITLE}"
+          }
+
+          wait_for_release_owned_for_containment() {
+            local destination="$1"
+            local release_id="$2"
+            local deadline=$((SECONDS + 60))
+            local query_status
+
+            while true; do
+              if query_release_by_id_for_convergence "${release_id}" "${destination}"; then
+                if verify_release_owned_for_containment "${destination}" "${release_id}"; then
+                  return 0
+                fi
+                echo "Containment readback for release ID ${release_id} changed immutable ID, tag, title, or ownership marker." >&2
+                return 1
+              else
+                query_status=$?
+                if [[ "${query_status}" -ne 75 ]]; then
+                  return 1
+                fi
+              fi
+
+              if (( SECONDS >= deadline )); then
+                echo "Containment could not prove immutable-ID ownership for release ID ${release_id} within 60 seconds; no mutation was attempted." >&2
+                return 1
+              fi
+              /bin/sleep 2
+            done
           }
 
           wait_for_release_contained_by_id() {
@@ -1619,28 +1694,22 @@ jobs:
           }
 
           contain_release_by_id() {
-            local mutation_status query_status discovery_status
+            local mutation_status query_status
             local containment_response="${RUNNER_TEMP}/vifty-release-containment-response.json"
             local containment_state="${RUNNER_TEMP}/vifty-release-containment-state.json"
             local ownership_state="${RUNNER_TEMP}/vifty-release-containment-ownership.json"
             local discovered_state="${RUNNER_TEMP}/vifty-release-containment-discovery.json"
 
             if [[ -z "${RELEASE_ID}" ]]; then
-              if discover_owned_draft_by_tag "${discovered_state}"; then
-                RELEASE_ID="$(capture_owned_draft_release_id "${discovered_state}")" || return 1
+              if wait_for_owned_release_by_tag_for_containment "${discovered_state}"; then
+                RELEASE_ID="$(capture_created_release_id "${discovered_state}")" || return 1
               else
-                discovery_status=$?
-                if [[ "${discovery_status}" -eq 3 ]]; then
-                  echo "Containment readback confirms that no release exists for ${RELEASE_TAG}." >&2
-                  return 0
-                fi
                 echo "Containment could not prove marker ownership for a unique ${RELEASE_TAG} release; no mutation was attempted." >&2
                 return 1
               fi
             fi
 
-            if ! query_release_by_id "${RELEASE_ID}" "${ownership_state}" || \
-               ! verify_release_owned_for_containment "${ownership_state}" "${RELEASE_ID}"; then
+            if ! wait_for_release_owned_for_containment "${ownership_state}" "${RELEASE_ID}"; then
               echo "Containment refused to mutate release ID ${RELEASE_ID}: exact tag/title/marker ownership was not proved." >&2
               return 1
             fi
@@ -1738,8 +1807,9 @@ jobs:
 
           CREATE_RESPONSE_STATUS=1
           if [[ -s "${CREATE_RESPONSE}" ]]; then
-            if RELEASE_ID="$(capture_owned_draft_release_id "${CREATE_RESPONSE}")"; then
-              if ruby -rjson -e '
+            if RELEASE_ID="$(capture_created_release_id "${CREATE_RESPONSE}")"; then
+              if capture_owned_draft_release_id "${CREATE_RESPONSE}" > /dev/null && \
+                ruby -rjson -e '
                 release = JSON.parse(File.read(ARGV.fetch(0)))
                 payload = JSON.parse(File.read(ARGV.fetch(1)))
                 body = release["body"]
@@ -1753,13 +1823,13 @@ jobs:
               ' "${CREATE_RESPONSE}" "${CREATE_PAYLOAD}" "${EXPECTED_BODY_PATH}"; then
                 CREATE_RESPONSE_STATUS=0
               fi
-            else
-              RELEASE_ID=""
             fi
           fi
 
           CREATED_STATE="${RUNNER_TEMP}/vifty-release-created-state.json"
-          if [[ -n "${RELEASE_ID}" ]]; then
+          if [[ "${CREATE_STATUS}" -eq 0 ]] && \
+             [[ "${CREATE_RESPONSE_STATUS}" -eq 0 ]] && \
+             [[ -n "${RELEASE_ID}" ]]; then
             if wait_for_release_state_by_id "${CREATED_STATE}" "${RELEASE_ID}" true "${DRAFT_TITLE}" \
               "${EXPECTED_BODY_PATH}" "${EXPECTED_ASSETS_PATH}"; then
               CREATE_QUERY_STATUS=0

--- a/Tests/Ruby/WorkflowContractTests.rb
+++ b/Tests/Ruby/WorkflowContractTests.rb
@@ -4,6 +4,7 @@ require "fileutils"
 require "json"
 require "minitest/autorun"
 require "open3"
+require "shellwords"
 require "tmpdir"
 
 class WorkflowContractTests < Minitest::Test
@@ -299,6 +300,361 @@ class WorkflowContractTests < Minitest::Test
     )
   end
 
+  def test_created_draft_response_captures_repository_scoped_immutable_id_before_marker_validation
+    code = release_inline_ruby(
+      "capture_created_release_id()",
+      "capture_owned_draft_release_id()"
+    )
+    response = {
+      "id" => 356_237_268,
+      "url" => "https://api.github.com/repos/Reedtrullz/Vifty/releases/356237268",
+      "assets_url" => "https://api.github.com/repos/Reedtrullz/Vifty/releases/356237268/assets",
+      "upload_url" => "https://uploads.github.com/repos/Reedtrullz/Vifty/releases/356237268/assets{?name,label}",
+      "tag_name" => "v1.4.2",
+      "draft" => true,
+      "prerelease" => false,
+      "assets" => []
+    }
+
+    path = write_json_fixture("created-draft.json", response)
+    stdout, stderr, status = Open3.capture3(
+      "/usr/bin/ruby", "-rjson", "-e", code,
+      path, "Reedtrullz/Vifty", "v1.4.2"
+    )
+
+    assert_predicate status, :success?, stderr
+    assert_equal "356237268", stdout
+
+    response["draft"] = false
+    response["prerelease"] = true
+    response["assets"] = [{ "id" => 1 }]
+    response["name"] = "unexpected mutable state"
+    path = write_json_fixture("anomalous-created-release.json", response)
+    stdout, stderr, status = Open3.capture3(
+      "/usr/bin/ruby", "-rjson", "-e", code,
+      path, "Reedtrullz/Vifty", "v1.4.2"
+    )
+
+    assert_predicate status, :success?, stderr
+    assert_equal "356237268", stdout,
+      "repository-scoped immutable ID retention must not depend on mutable publication state"
+
+    response["url"] = "https://api.github.com/repos/other/repository/releases/356237268"
+    path = write_json_fixture("wrong-repository-draft.json", response)
+    _stdout, stderr, status = Open3.capture3(
+      "/usr/bin/ruby", "-rjson", "-e", code,
+      path, "Reedtrullz/Vifty", "v1.4.2"
+    )
+
+    refute_predicate status, :success?
+    assert_includes stderr, "repository-scoped ID/tag identity"
+  end
+
+  def test_owned_draft_marker_count_is_literal_exact_and_single
+    code = release_inline_ruby(
+      "capture_owned_draft_release_id()",
+      "discover_owned_release_by_tag_for_containment()"
+    )
+    marker = "<!-- vifty-release-owner:29668876169:1:b5627041 -->"
+    title = "Vifty 1.4.2 [draft b5627041]"
+    response = {
+      "id" => 356_237_268,
+      "tag_name" => "v1.4.2",
+      "draft" => true,
+      "name" => title,
+      "body" => "release checklist\n\n#{marker}\n",
+      "assets" => []
+    }
+
+    assert_equal 1, response.fetch("body").scan(marker).length
+    assert_equal 0, response.fetch("body").scan(Regexp.escape(marker)).length,
+      "escaped String scan must reproduce the retired v1.4.1 validator bug"
+
+    path = write_json_fixture("owned-draft.json", response)
+    stdout, stderr, status = Open3.capture3(
+      "/usr/bin/ruby", "-rjson", "-e", code,
+      path, "v1.4.2", title, marker
+    )
+    assert_predicate status, :success?, stderr
+    assert_equal "356237268", stdout
+
+    response["body"] = "#{marker}\n#{marker}\n"
+    path = write_json_fixture("duplicate-marker-draft.json", response)
+    _stdout, _stderr, status = Open3.capture3(
+      "/usr/bin/ruby", "-rjson", "-e", code,
+      path, "v1.4.2", title, marker
+    )
+    refute_predicate status, :success?
+
+    response["body"] = "prefix #{marker} suffix\n"
+    path = write_json_fixture("inline-marker-draft.json", response)
+    _stdout, _stderr, status = Open3.capture3(
+      "/usr/bin/ruby", "-rjson", "-e", code,
+      path, "v1.4.2", title, marker
+    )
+    refute_predicate status, :success?
+  end
+
+  def test_post_creation_release_discovery_retries_empty_then_visible_and_fails_closed_on_persistent_absence
+    function = release_shell_function(
+      "wait_for_owned_release_by_tag_for_containment()",
+      "verify_release_state()"
+    )
+    destination = File.join(@fixture_root, "discovered-draft.json")
+    retry_script = <<~BASH
+      set -euo pipefail
+      RELEASE_TAG=v1.4.2
+      attempts=0
+      discover_owned_release_by_tag_for_containment() {
+        attempts=$((attempts + 1))
+        if [[ "${attempts}" -eq 1 ]]; then
+          return 3
+        fi
+        printf '{}\n' > "$1"
+        return 0
+      }
+      #{function}
+      wait_for_owned_release_by_tag_for_containment #{Shellwords.escape(destination)}
+      test "${attempts}" -eq 2
+    BASH
+    _stdout, stderr, status = Open3.capture3("/bin/bash", "-c", retry_script)
+    assert_predicate status, :success?, stderr
+
+    absence_script = <<~BASH
+      set -euo pipefail
+      RELEASE_TAG=v1.4.2
+      discover_owned_release_by_tag_for_containment() {
+        SECONDS="${deadline}"
+        return 3
+      }
+      #{function}
+      if wait_for_owned_release_by_tag_for_containment #{Shellwords.escape(destination)}; then
+        exit 99
+      fi
+    BASH
+    _stdout, stderr, status = Open3.capture3("/bin/bash", "-c", absence_script)
+    assert_predicate status, :success?, stderr
+    assert_includes stderr, "could not prove post-creation absence or exact marker ownership"
+  end
+
+  def test_containment_retries_owned_id_before_patch_and_never_patches_unproved_ownership
+    ownership_wait = release_shell_function(
+      "wait_for_release_owned_for_containment()",
+      "wait_for_release_contained_by_id()"
+    )
+    containment = release_shell_function(
+      "contain_release_by_id()",
+      "containment_guard()"
+    )
+    runner_temp = Shellwords.escape(@fixture_root)
+
+    success_script = <<~BASH
+      set -euo pipefail
+      RUNNER_TEMP=#{runner_temp}
+      RELEASE_ID=356237268
+      RELEASE_TAG=v1.4.2
+      GITHUB_REPOSITORY=Reedtrullz/Vifty
+      query_attempts=0
+      patch_attempts=0
+      query_release_by_id_for_convergence() {
+        query_attempts=$((query_attempts + 1))
+        if [[ "${query_attempts}" -eq 1 ]]; then
+          return 75
+        fi
+        printf '{}\n' > "$2"
+      }
+      verify_release_owned_for_containment() { return 0; }
+      release_gh() { patch_attempts=$((patch_attempts + 1)); printf '{}\n'; }
+      wait_for_release_contained_by_id() { printf '{}\n' > "$1"; }
+      verify_release_contained() { return 0; }
+      wait_for_owned_release_by_tag_for_containment() { return 1; }
+      capture_created_release_id() { return 1; }
+      #{ownership_wait}
+      #{containment}
+      contain_release_by_id
+      test "${query_attempts}" -eq 2
+      test "${patch_attempts}" -eq 1
+    BASH
+    _stdout, stderr, status = Open3.capture3("/bin/bash", "-c", success_script)
+    assert_predicate status, :success?, stderr
+
+    persistent_script = <<~BASH
+      set -euo pipefail
+      RUNNER_TEMP=#{runner_temp}
+      RELEASE_ID=356237268
+      RELEASE_TAG=v1.4.2
+      GITHUB_REPOSITORY=Reedtrullz/Vifty
+      patch_attempts=0
+      query_release_by_id_for_convergence() { SECONDS="${deadline}"; return 75; }
+      verify_release_owned_for_containment() { return 0; }
+      release_gh() { patch_attempts=$((patch_attempts + 1)); printf '{}\n'; }
+      wait_for_release_contained_by_id() { return 0; }
+      verify_release_contained() { return 0; }
+      wait_for_owned_release_by_tag_for_containment() { return 1; }
+      capture_created_release_id() { return 1; }
+      #{ownership_wait}
+      #{containment}
+      if contain_release_by_id; then
+        exit 99
+      fi
+      test "${patch_attempts}" -eq 0
+    BASH
+    _stdout, stderr, status = Open3.capture3("/bin/bash", "-c", persistent_script)
+    assert_predicate status, :success?, stderr
+    assert_includes stderr, "no mutation was attempted"
+
+    mismatch_script = <<~BASH
+      set -euo pipefail
+      RUNNER_TEMP=#{runner_temp}
+      RELEASE_ID=356237268
+      RELEASE_TAG=v1.4.2
+      GITHUB_REPOSITORY=Reedtrullz/Vifty
+      patch_attempts=0
+      query_release_by_id_for_convergence() { printf '{}\n' > "$2"; }
+      verify_release_owned_for_containment() { return 1; }
+      release_gh() { patch_attempts=$((patch_attempts + 1)); printf '{}\n'; }
+      wait_for_release_contained_by_id() { return 0; }
+      verify_release_contained() { return 0; }
+      wait_for_owned_release_by_tag_for_containment() { return 1; }
+      capture_created_release_id() { return 1; }
+      #{ownership_wait}
+      #{containment}
+      if contain_release_by_id; then
+        exit 99
+      fi
+      test "${patch_attempts}" -eq 0
+    BASH
+    _stdout, stderr, status = Open3.capture3("/bin/bash", "-c", mismatch_script)
+    assert_predicate status, :success?, stderr
+    assert_includes stderr, "changed immutable ID, tag, title, or ownership marker"
+  end
+
+  def test_ambiguous_creation_with_retained_id_enters_containment_without_state_poll
+    creation_state = release_shell_function(
+      'CREATED_STATE="${RUNNER_TEMP}/vifty-release-created-state.json"',
+      'if ! upload_release_asset_by_id "${ZIP_PATH}"'
+    )
+    contained_path = File.join(@fixture_root, "creation-contained")
+    wait_called_path = File.join(@fixture_root, "creation-wait-called")
+    verify_called_path = File.join(@fixture_root, "creation-verify-called")
+    script = <<~BASH
+      set -uo pipefail
+      RUNNER_TEMP=#{Shellwords.escape(@fixture_root)}
+      CREATE_STATUS=0
+      CREATE_RESPONSE_STATUS=1
+      CREATE_QUERY_STATUS=99
+      RELEASE_ID=356237268
+      DRAFT_TITLE='Vifty 1.4.2 [draft nonce]'
+      EXPECTED_BODY_PATH=#{Shellwords.escape(File.join(@fixture_root, "missing-body"))}
+      EXPECTED_ASSETS_PATH=#{Shellwords.escape(File.join(@fixture_root, "expected-assets"))}
+      containment_guard() { printf 'contained\n' > #{Shellwords.escape(contained_path)}; }
+      wait_for_release_state_by_id() {
+        printf 'called\n' > #{Shellwords.escape(wait_called_path)}
+        return 0
+      }
+      verify_release_state() {
+        printf 'called\n' > #{Shellwords.escape(verify_called_path)}
+        return 0
+      }
+      trap containment_guard EXIT
+      #{creation_state}
+      exit 99
+    BASH
+
+    _stdout, stderr, status = Open3.capture3("/bin/bash", "-c", script)
+
+    refute_predicate status, :success?
+    assert_equal "contained\n", File.binread(contained_path), stderr
+    refute File.exist?(wait_called_path), "creation convergence poll unexpectedly ran"
+    refute File.exist?(verify_called_path), "creation state verification unexpectedly ran"
+  end
+
+  def test_rejects_escaped_string_marker_scan_regression
+    mutate_all_release_workflow(
+      "body.scan(marker).length == 1",
+      "body.scan(Regexp.escape(marker)).length == 1"
+    )
+
+    assert_contract_failure(
+      "publish may discover an ambiguous draft by tag only with exact immutable-ID/tag/draft/title/marker ownership proof"
+    )
+  end
+
+  def test_rejects_clearing_captured_release_id_after_marker_validation_failure
+    mutate_release_workflow(
+      "              fi\n            fi\n          fi\n\n          CREATED_STATE=",
+      "              fi\n            else\n              RELEASE_ID=\"\"\n            fi\n          fi\n\n          CREATED_STATE="
+    )
+
+    assert_contract_failure(
+      "publish must REST-create the marked draft, capture its immutable ID directly, and forbid " \
+      "tag-based release mutation"
+    )
+  end
+
+  def test_rejects_coupling_immutable_release_id_retention_to_mutable_draft_state
+    mutate_release_workflow(
+      'release["tag_name"] == tag',
+      'release["tag_name"] == tag && release["draft"] == true'
+    )
+
+    assert_contract_failure(
+      "publish must retain the repository-scoped created release ID independently of mutable " \
+      "draft, publication, asset, title, or body state"
+    )
+  end
+
+  def test_rejects_single_by_id_read_before_containment_patch
+    mutate_release_workflow(
+      'wait_for_release_owned_for_containment "${ownership_state}" "${RELEASE_ID}"',
+      'query_release_by_id "${RELEASE_ID}" "${ownership_state}" && ' \
+      'verify_release_owned_for_containment "${ownership_state}" "${RELEASE_ID}"'
+    )
+
+    assert_contract_failure(
+      "publish containment must prove owned immutable-ID state with bounded GET-only retries " \
+      "before its single re-draft mutation"
+    )
+  end
+
+  def test_rejects_creation_state_poll_guarded_only_by_retained_id
+    mutate_release_workflow(
+      "if [[ \"${CREATE_STATUS}\" -eq 0 ]] && \\\n" \
+      "             [[ \"${CREATE_RESPONSE_STATUS}\" -eq 0 ]] && \\\n" \
+      "             [[ -n \"${RELEASE_ID}\" ]]; then",
+      'if [[ -n "${RELEASE_ID}" ]]; then'
+    )
+
+    assert_contract_failure(
+      "publish must enter containment immediately after ambiguous creation instead of polling " \
+      "state without a validated direct response body"
+    )
+  end
+
+  def test_rejects_single_empty_release_list_as_post_creation_containment_proof
+    mutate_release_workflow(
+      'wait_for_owned_release_by_tag_for_containment "${discovered_state}"',
+      'discover_owned_release_by_tag_for_containment "${discovered_state}"'
+    )
+
+    assert_contract_failure(
+      "publish must re-draft by immutable release ID on every ambiguous failure and hard-fail " \
+      "unless containment readback succeeds"
+    )
+  end
+
+  def test_rejects_losing_discovery_exit_status_after_failed_if_condition
+    mutate_release_workflow(
+      "              else\n                discovery_status=$?\n              fi",
+      "              fi\n              discovery_status=$?"
+    )
+
+    assert_contract_failure(
+      "publish must re-draft by immutable release ID on every ambiguous failure and hard-fail " \
+      "unless containment readback succeeds"
+    )
+  end
+
   def test_rejects_prerelease_readback_drift
     mutate_all_release_workflow(
       'release["prerelease"] == false',
@@ -349,8 +705,22 @@ class WorkflowContractTests < Minitest::Test
 
   def test_rejects_unbounded_release_state_convergence
     mutate_release_workflow(
-      '            local deadline=$((SECONDS + 60))',
-      '            local deadline=$((SECONDS + 600))'
+      "          wait_for_release_state_by_id() {\n" \
+      "            local destination=\"$1\"\n" \
+      "            local release_id=\"$2\"\n" \
+      "            local expected_draft=\"$3\"\n" \
+      "            local expected_title=\"$4\"\n" \
+      "            local expected_body_path=\"$5\"\n" \
+      "            local expected_assets_path=\"$6\"\n" \
+      "            local deadline=$((SECONDS + 60))",
+      "          wait_for_release_state_by_id() {\n" \
+      "            local destination=\"$1\"\n" \
+      "            local release_id=\"$2\"\n" \
+      "            local expected_draft=\"$3\"\n" \
+      "            local expected_title=\"$4\"\n" \
+      "            local expected_body_path=\"$5\"\n" \
+      "            local expected_assets_path=\"$6\"\n" \
+      "            local deadline=$((SECONDS + 600))"
     )
 
     assert_contract_failure(
@@ -751,6 +1121,33 @@ class WorkflowContractTests < Minitest::Test
     updated = original.sub(needle, replacement)
     refute_equal original, updated
     File.binwrite(path, updated)
+  end
+
+  def release_inline_ruby(function_name, next_function_name)
+    workflow = File.binread(release_workflow_path)
+    start_index = workflow.index(function_name)
+    refute_nil start_index, "missing #{function_name} in release workflow"
+    end_index = workflow.index(next_function_name, start_index + function_name.length)
+    refute_nil end_index, "missing #{next_function_name} after #{function_name}"
+    function_text = workflow[start_index...end_index]
+    match = function_text.match(/ruby -rjson -e '\n(?<code>.*?)\n\s*' "\$\{state_path\}"/m)
+    refute_nil match, "could not extract inline Ruby from #{function_name}"
+    match[:code]
+  end
+
+  def release_shell_function(function_name, next_function_name)
+    workflow = File.binread(release_workflow_path)
+    start_index = workflow.index(function_name)
+    refute_nil start_index, "missing #{function_name} in release workflow"
+    end_index = workflow.index(next_function_name, start_index + function_name.length)
+    refute_nil end_index, "missing #{next_function_name} after #{function_name}"
+    workflow[start_index...end_index]
+  end
+
+  def write_json_fixture(name, value)
+    path = File.join(@fixture_root, name)
+    File.binwrite(path, JSON.generate(value) + "\n")
+    path
   end
 
   def assert_contract_failure(diagnostic)

--- a/Tests/ViftyCoreTests/ReleaseManifestScriptTests.swift
+++ b/Tests/ViftyCoreTests/ReleaseManifestScriptTests.swift
@@ -1400,7 +1400,7 @@ final class ReleaseManifestScriptTests: XCTestCase {
         let fixture = try WorkflowContractFixture(repositoryRoot: repositoryRoot)
         try fixture.mutateReleaseWorkflow { workflow in
             workflow.replacingOccurrences(
-                of: "RELEASE_ID=\"$(capture_owned_draft_release_id \"${CREATE_RESPONSE}\")\"",
+                of: "RELEASE_ID=\"$(capture_created_release_id \"${CREATE_RESPONSE}\")\"",
                 with: "RELEASE_ID=\"123\""
             )
         }
@@ -1414,12 +1414,12 @@ final class ReleaseManifestScriptTests: XCTestCase {
         )
     }
 
-    func testWorkflowContractRejectsMarkerBlindAmbiguousDraftDiscovery() throws {
+    func testWorkflowContractRejectsEscapedStringMarkerScanRegression() throws {
         let fixture = try WorkflowContractFixture(repositoryRoot: repositoryRoot)
         try fixture.mutateReleaseWorkflow { workflow in
             workflow.replacingOccurrences(
-                of: "body.scan(Regexp.escape(marker)).length == 1",
-                with: "body.include?(marker)"
+                of: "body.scan(marker).length == 1",
+                with: "body.scan(Regexp.escape(marker)).length == 1"
             )
         }
 
@@ -1428,6 +1428,42 @@ final class ReleaseManifestScriptTests: XCTestCase {
         XCTAssertNotEqual(result.exitCode, 0)
         XCTAssertTrue(
             result.stderr.contains("exact immutable-ID/tag/draft/title/marker ownership proof"),
+            result.stderr
+        )
+    }
+
+    func testWorkflowContractRejectsClearingCapturedReleaseIDAfterOwnershipMismatch() throws {
+        let fixture = try WorkflowContractFixture(repositoryRoot: repositoryRoot)
+        try fixture.mutateReleaseWorkflow { workflow in
+            workflow.replacingOccurrences(
+                of: "              fi\n            fi\n          fi\n\n          CREATED_STATE=",
+                with: "              fi\n            else\n              RELEASE_ID=\"\"\n            fi\n          fi\n\n          CREATED_STATE="
+            )
+        }
+
+        let result = try fixture.runChecker()
+
+        XCTAssertNotEqual(result.exitCode, 0)
+        XCTAssertTrue(
+            result.stderr.contains("capture its immutable ID directly"),
+            result.stderr
+        )
+    }
+
+    func testWorkflowContractRejectsSingleEmptyPostCreationListAsContainmentProof() throws {
+        let fixture = try WorkflowContractFixture(repositoryRoot: repositoryRoot)
+        try fixture.mutateReleaseWorkflow { workflow in
+            workflow.replacingOccurrences(
+                of: "wait_for_owned_release_by_tag_for_containment \"${discovered_state}\"",
+                with: "discover_owned_release_by_tag_for_containment \"${discovered_state}\""
+            )
+        }
+
+        let result = try fixture.runChecker()
+
+        XCTAssertNotEqual(result.exitCode, 0)
+        XCTAssertTrue(
+            result.stderr.contains("hard-fail unless containment readback succeeds"),
             result.stderr
         )
     }

--- a/Tests/ViftyCoreTests/ReleaseMetadataScriptTests.swift
+++ b/Tests/ViftyCoreTests/ReleaseMetadataScriptTests.swift
@@ -437,6 +437,27 @@ final class ReleaseMetadataScriptTests: XCTestCase {
         XCTAssertTrue(result.stderr.contains("must not mutate a GitHub Release by tag"))
     }
 
+    func testValidatorRejectsDeferringImmutableReleaseIDCaptureUntilFullOwnershipValidation() throws {
+        let harness = try ReleaseMetadataHarness()
+        let workflowURL = harness.rootURL.appendingPathComponent(".github/workflows/release.yml")
+        var workflow = try String(contentsOf: workflowURL, encoding: .utf8)
+        let immutableCapture = "RELEASE_ID=\"$(capture_created_release_id \"${CREATE_RESPONSE}\")\""
+        XCTAssertTrue(workflow.contains(immutableCapture))
+        workflow = workflow.replacingOccurrences(
+            of: immutableCapture,
+            with: "RELEASE_ID=\"$(capture_owned_draft_release_id \"${CREATE_RESPONSE}\")\""
+        )
+        try workflow.write(to: workflowURL, atomically: true, encoding: .utf8)
+
+        let result = try harness.runValidator()
+
+        XCTAssertEqual(result.exitCode, 1)
+        XCTAssertTrue(
+            result.stderr.contains("retain its repository-scoped immutable release ID before full ownership validation"),
+            result.stderr
+        )
+    }
+
     func testCaskChecksumUpdaterAppliesReleaseChecksumAndRevalidatesMetadata() throws {
         let newSHA = String(repeating: "b", count: 64)
         let harness = try ReleaseMetadataHarness(manifestSHA: newSHA)
@@ -3038,7 +3059,8 @@ private final class ReleaseMetadataHarness {
                   gh api --method POST \\
                     "repos/${GITHUB_REPOSITORY}/releases" \\
                     --input "${CREATE_PAYLOAD}" > "${CREATE_RESPONSE}"
-                  RELEASE_ID="$(capture_owned_draft_release_id "${CREATE_RESPONSE}")"
+                  RELEASE_ID="$(capture_created_release_id "${CREATE_RESPONSE}")"
+                  capture_owned_draft_release_id "${CREATE_RESPONSE}" > /dev/null
                   ruby -rjson -e '
                     data = JSON.parse(File.read(ARGV.fetch(0)))
                     contract = JSON.parse(File.read(ARGV.fetch(1)))

--- a/scripts/check-workflow-contract.rb
+++ b/scripts/check-workflow-contract.rb
@@ -1256,7 +1256,7 @@ else
     expected_step_hashes = {
       "Download verified release assets" => "2efd54639fbb126e0ce7aa6fcb477987a276e7b0a98d6ecfb745a1b25df99dc8",
       "Recheck downloaded asset identity" => "aa5a51382d16e1ad1b73abec06a173c75673c05b43bad9ccf55e664aa7573c00",
-      "Publish GitHub release" => "6cfcb858c1f9e062754cd855400f815626db74295c828e4ec5fdfd5c977570ae"
+      "Publish GitHub release" => "c6973fdcbfdca69f26527ae1792153c4de039bd9818a2d10f646d80de25424e4"
     }
     names = steps.map { |step| step.is_a?(Hash) ? step["name"] : nil }
     errors << "publish step set must match the reviewed allowlist exactly" unless names == expected_step_hashes.keys
@@ -1379,13 +1379,53 @@ else
            publish_run_text.include?('--input "${CREATE_PAYLOAD}" > "${CREATE_RESPONSE}"') &&
            publish_run_text.include?('body.b.start_with?(submitted_body.b)') &&
            publish_run_text.include?('release["prerelease"] == false') &&
-           publish_run_text.include?('RELEASE_ID="$(capture_owned_draft_release_id "${CREATE_RESPONSE}")"') &&
+           publish_run_text.include?("capture_created_release_id()") &&
+           publish_run_text.include?('release["url"] == api_base') &&
+           publish_run_text.include?('release["assets_url"] == "#{api_base}/assets"') &&
+           publish_run_text.include?('release["upload_url"] == upload_url') &&
+           publish_run_text.include?('RELEASE_ID="$(capture_created_release_id "${CREATE_RESPONSE}")"') &&
+           publish_run_text.include?('capture_owned_draft_release_id "${CREATE_RESPONSE}" > /dev/null') &&
+           !publish_run_text.match?(/else\s+RELEASE_ID=""/) &&
            publish_run_text.include?('wait_for_release_state_by_id "${PUBLISHED_STATE}" "${RELEASE_ID}" false "${FINAL_TITLE}"') &&
            publish_run_text.include?('"repos/${GITHUB_REPOSITORY}/releases/${RELEASE_ID}"') &&
            publish_run_text.include?('-F draft=false') &&
            publish_run_text.include?('-F prerelease=false') &&
            !publish_run_text.match?(/gh release (?:create|edit|upload|delete)/)
       errors << "publish must REST-create the marked draft, capture its immutable ID directly, and forbid tag-based release mutation"
+    end
+    created_release_capture_start = publish_run_text.index("capture_created_release_id()")
+    created_release_capture_end = publish_run_text.index("capture_owned_draft_release_id()")
+    created_release_capture_text = if created_release_capture_start && created_release_capture_end &&
+                                      created_release_capture_start < created_release_capture_end
+                                     publish_run_text[created_release_capture_start...created_release_capture_end]
+                                   else
+                                     ""
+                                   end
+    unless created_release_capture_text.include?('id.is_a?(Integer) && id.positive?') &&
+           created_release_capture_text.include?('release["url"] == api_base') &&
+           created_release_capture_text.include?('release["assets_url"] == "#{api_base}/assets"') &&
+           created_release_capture_text.include?('release["upload_url"] == upload_url') &&
+           created_release_capture_text.include?('release["tag_name"] == tag') &&
+           !created_release_capture_text.include?('release["draft"]') &&
+           !created_release_capture_text.include?('release["prerelease"]') &&
+           !created_release_capture_text.include?('release["assets"]') &&
+           !created_release_capture_text.include?('release["name"]') &&
+           !created_release_capture_text.include?('release["body"]')
+      errors << "publish must retain the repository-scoped created release ID independently of mutable draft, publication, asset, title, or body state"
+    end
+    created_state_start = publish_run_text.index('CREATED_STATE="${RUNNER_TEMP}/vifty-release-created-state.json"')
+    created_state_end = publish_run_text.index('if ! upload_release_asset_by_id "${ZIP_PATH}"', created_state_start || 0)
+    created_state_text = if created_state_start && created_state_end && created_state_start < created_state_end
+                           publish_run_text[created_state_start...created_state_end]
+                         else
+                           ""
+                         end
+    unless created_state_text.include?('if [[ "${CREATE_STATUS}" -eq 0 ]] &&') &&
+           created_state_text.include?('[[ "${CREATE_RESPONSE_STATUS}" -eq 0 ]] &&') &&
+           created_state_text.include?('[[ -n "${RELEASE_ID}" ]]; then') &&
+           created_state_text.include?('wait_for_release_state_by_id "${CREATED_STATE}" "${RELEASE_ID}" true "${DRAFT_TITLE}"') &&
+           !created_state_text.include?('if [[ -n "${RELEASE_ID}" ]]; then')
+      errors << "publish must enter containment immediately after ambiguous creation instead of polling state without a validated direct response body"
     end
     errors << "publish must pin every GitHub CLI API call to github.com" if publish_run_text.scan(/gh api(?! --hostname github\.com)/).any?
     unless publish_run_text.include?("upload_release_asset_by_id()") &&
@@ -1410,7 +1450,7 @@ else
            convergence_text.include?('verify_release_convergence_identity') &&
            convergence_text.include?('release["id"] == Integer(ARGV.fetch(1), 10)') &&
            convergence_text.include?('release["tag_name"] == ARGV.fetch(2)') &&
-           convergence_text.include?('body.scan(Regexp.escape(marker)).length == 1') &&
+           convergence_text.include?('body.scan(marker).length == 1') &&
            !convergence_text.include?('--method POST') &&
            !convergence_text.include?('--method PATCH') &&
            !convergence_text.include?('--request POST') &&
@@ -1428,18 +1468,27 @@ else
            publish_run_text.include?('verify_release_state "${PUBLISHED_STATE}"')
       errors << "publish must bind exact returned body plus immutable asset IDs, sizes, states, and digests through promotion readback"
     end
-    unless publish_run_text.include?("discover_owned_draft_by_tag()") &&
+    unless publish_run_text.include?("discover_owned_release_by_tag_for_containment()") &&
            publish_run_text.include?("capture_owned_draft_release_id()") &&
-           publish_run_text.include?('body.scan(Regexp.escape(marker)).length == 1') &&
+           publish_run_text.scan('body.scan(marker).length == 1').length == 4 &&
+           !publish_run_text.include?('body.scan(Regexp.escape(marker)).length == 1') &&
            publish_run_text.include?('release["name"] == ARGV.fetch(2)') &&
            publish_run_text.include?('Array(release["assets"]).empty?') &&
-           publish_run_text.include?('verify_release_owned_for_containment "${ownership_state}" "${RELEASE_ID}"') &&
+           publish_run_text.include?('discovered_release_id="$(capture_created_release_id "${destination}")"') &&
+           publish_run_text.include?('wait_for_release_owned_for_containment "${ownership_state}" "${RELEASE_ID}"') &&
            publish_run_text.include?("no mutation was attempted")
       errors << "publish may discover an ambiguous draft by tag only with exact immutable-ID/tag/draft/title/marker ownership proof"
     end
     unless publish_run_text.include?("contain_release_by_id()") &&
            publish_run_text.include?("verify_release_contained()") &&
+           publish_run_text.include?("wait_for_release_owned_for_containment()") &&
            publish_run_text.include?("wait_for_release_contained_by_id()") &&
+           publish_run_text.include?("wait_for_owned_release_by_tag_for_containment()") &&
+           publish_run_text.include?('local deadline=$((SECONDS + 60))') &&
+           publish_run_text.include?("if discover_owned_release_by_tag_for_containment \"${destination}\"; then\n      return 0\n    else\n      discovery_status=$?\n    fi") &&
+           publish_run_text.include?('wait_for_owned_release_by_tag_for_containment "${discovered_state}"') &&
+           publish_run_text.include?('Containment could not prove post-creation absence or exact marker ownership') &&
+           !publish_run_text.include?('Containment readback confirms that no release exists') &&
            publish_run_text.include?("CONTAINMENT_REQUIRED=1") &&
            publish_run_text.include?("trap containment_guard EXIT") &&
            publish_run_text.include?("trap 'exit 130' INT") &&
@@ -1452,6 +1501,33 @@ else
            publish_run_text.include?("exit 97") &&
            !publish_run_text.include?("|| true")
       errors << "publish must re-draft by immutable release ID on every ambiguous failure and hard-fail unless containment readback succeeds"
+    end
+    containment_ownership_wait_start = publish_run_text.index("wait_for_release_owned_for_containment()")
+    containment_ownership_wait_end = publish_run_text.index("wait_for_release_contained_by_id()")
+    containment_ownership_wait_text = if containment_ownership_wait_start && containment_ownership_wait_end &&
+                                         containment_ownership_wait_start < containment_ownership_wait_end
+                                        publish_run_text[containment_ownership_wait_start...containment_ownership_wait_end]
+                                      else
+                                        ""
+                                      end
+    containment_function_start = publish_run_text.index("contain_release_by_id()")
+    containment_function_text = containment_function_start ? publish_run_text[containment_function_start..] : ""
+    ownership_call_index = containment_function_text.index(
+      'wait_for_release_owned_for_containment "${ownership_state}" "${RELEASE_ID}"'
+    )
+    containment_patch_index = containment_function_text.index(
+      'release_gh api --hostname github.com --method PATCH'
+    )
+    unless containment_ownership_wait_text.include?('local deadline=$((SECONDS + 60))') &&
+           containment_ownership_wait_text.include?('query_release_by_id_for_convergence "${release_id}" "${destination}"') &&
+           containment_ownership_wait_text.include?('verify_release_owned_for_containment "${destination}" "${release_id}"') &&
+           containment_ownership_wait_text.include?('no mutation was attempted') &&
+           containment_ownership_wait_text.include?('/bin/sleep 2') &&
+           !containment_ownership_wait_text.include?('--method POST') &&
+           !containment_ownership_wait_text.include?('--method PATCH') &&
+           !containment_ownership_wait_text.include?('--request POST') &&
+           ownership_call_index && containment_patch_index && ownership_call_index < containment_patch_index
+      errors << "publish containment must prove owned immutable-ID state with bounded GET-only retries before its single re-draft mutation"
     end
     containment_wait_start = publish_run_text.index("wait_for_release_contained_by_id()")
     containment_wait_end = publish_run_text.index("upload_release_asset_by_id()")

--- a/scripts/validate-release-metadata.sh
+++ b/scripts/validate-release-metadata.sh
@@ -460,8 +460,9 @@ fi
 if ! { grep -Fq 'gh api --method POST' "${RELEASE_WORKFLOW}" ||
        grep -Fq 'gh api --hostname github.com --method POST' "${RELEASE_WORKFLOW}"; } ||
    ! grep -Fq '"repos/${GITHUB_REPOSITORY}/releases"' "${RELEASE_WORKFLOW}" ||
-   ! grep -Fq 'RELEASE_ID="$(capture_owned_draft_release_id "${CREATE_RESPONSE}")"' "${RELEASE_WORKFLOW}"; then
-  echo "error: ${RELEASE_WORKFLOW} must REST-create the draft and capture its immutable release ID directly" >&2
+   ! grep -Fq 'RELEASE_ID="$(capture_created_release_id "${CREATE_RESPONSE}")"' "${RELEASE_WORKFLOW}" ||
+   ! grep -Fq 'capture_owned_draft_release_id "${CREATE_RESPONSE}" > /dev/null' "${RELEASE_WORKFLOW}"; then
+  echo "error: ${RELEASE_WORKFLOW} must REST-create the draft, retain its repository-scoped immutable release ID before full ownership validation, and then validate ownership" >&2
   exit 1
 fi
 


### PR DESCRIPTION
Fixes the failure mode that retired v1.4.1: the publish step created a draft whose direct immutable-ID/marker post-state did not match, and by-tag containment could not prove ownership because GitHub's release-list API served cached data.

## Changes
- Require the created release's immutable repository-scoped ID plus exact tag/title/ownership-marker match on both the create response and every by-tag readback.
- Add `Cache-Control: no-cache` / `Pragma: no-cache` to the paginated release-list queries so containment sees current state.
- Wait (bounded, 60s) for the created release to converge instead of treating a not-yet-visible release as absence.
- Fail closed on any mismatch: no mutation is attempted unless exact ownership is proven.
- Update `check-workflow-contract.rb`, `validate-release-metadata.sh`, and their test suites to pin the new publish-step contract (including `body.scan(marker)` semantics, no `else RELEASE_ID=""`, and the created-ID capture).

## Verification (local, before push)
- `/usr/bin/ruby Tests/Ruby/WorkflowContractTests.rb`: 65 runs, 396 assertions, 0 failures.
- `scripts/validate-release-metadata.sh --mode developer-id`: OK (1.4.1 / Vifty-v1.4.1.zip).
- `git diff --cached --check`: clean.

## Non-claims
- No release/tag/GitHub Release mutation. v1.4.1 remains retired without publication; a new patch candidate follows separately after this and the remaining remediation land.