### PR TITLE
Raise release workflow prepare-candidate timeout to 60 minutes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
   prepare-candidate:
     name: Build and inventory unsigned candidate
     runs-on: macos-15
-    timeout-minutes: 35
+    timeout-minutes: 60
     permissions:
       actions: read
       contents: read

--- a/Tests/Ruby/WorkflowContractTests.rb
+++ b/Tests/Ruby/WorkflowContractTests.rb
@@ -301,6 +301,22 @@ class WorkflowContractTests < Minitest::Test
     )
   end
 
+  def test_rejects_prepare_candidate_timeout_drift
+    mutate_release_workflow(
+      "    name: Build and inventory unsigned candidate\n" \
+      "    runs-on: macos-15\n" \
+      "    timeout-minutes: 60\n",
+      "    name: Build and inventory unsigned candidate\n" \
+      "    runs-on: macos-15\n" \
+      "    timeout-minutes: 30\n"
+    )
+
+    assert_contract_failure(
+      ".github/workflows/release.yml job prepare-candidate wrapper must match the reviewed runner, " \
+      "timeout, dependencies, permissions, environment, and fields exactly"
+    )
+  end
+
   def test_rejects_draft_creation_body_prefix_drift
     mutate_release_workflow(
       "body.b.start_with?(submitted_body.b)",

--- a/scripts/check-workflow-contract.rb
+++ b/scripts/check-workflow-contract.rb
@@ -185,7 +185,7 @@ expected_job_wrappers = {
     "prepare-candidate" => {
       "name" => "Build and inventory unsigned candidate",
       "runs-on" => "macos-15",
-      "timeout-minutes" => 35,
+      "timeout-minutes" => 60,
       "permissions" => { "actions" => "read", "contents" => "read" },
       "env" => {
         "RELEASE_TAG" => "${{ github.ref_name }}"


### PR DESCRIPTION
The v1.4.3 Release run was cancelled at the 35-minute `prepare-candidate` timeout after the full read-only build and test gate crossed it (the same margin failure fixed for CI in PR #28). The cancellation happened before signing, notarization, or publication; no release exists. This raises `prepare-candidate` to 60 minutes, pins the value in the workflow contract checker, and adds a mutation test.

## Verification
- `check-workflow-contract.rb`: OK.
- Ruby contract suite: 67 runs, 408 assertions, 0 failures.

## Non-claims
- v1.4.3 remains retired without publication (one-shot contract: no rerun or tag reuse). The next patch candidate follows in a separate prep PR.