### PR TITLE
Fix public-archive installer under the hostile C-locale environment

### DIFF
--- a/scripts/release-candidate-inventory.rb
+++ b/scripts/release-candidate-inventory.rb
@@ -106,7 +106,7 @@ module ViftyCandidateInventory
   end
 
   def validate_relative_path!(path, label, allow_root: false)
-    fail_inventory("#{label} must be valid UTF-8") unless path.is_a?(String) && path.encoding == Encoding::UTF_8 && path.valid_encoding?
+    fail_inventory("#{label} must be valid UTF-8") unless utf8_representable?(path)
     fail_inventory("#{label} contains a control character") if path.match?(/[\x00-\x1f\x7f]/)
     return if allow_root && path == "."
     fail_inventory("#{label} must be a non-empty relative path") if path.empty? || path.start_with?("/")
@@ -116,9 +116,20 @@ module ViftyCandidateInventory
     fail_inventory("#{label} exceeds #{MAX_PATH_DEPTH} path components") if components.length > MAX_PATH_DEPTH
   end
 
+  # Accepts UTF-8-tagged strings and ASCII-8BIT names reported by the
+  # filesystem under a C locale (LANG=C hostile-environment hardening); the
+  # requirement is that the bytes represent valid UTF-8, not a specific Ruby
+  # encoding tag.
+  def utf8_representable?(value)
+    return false unless value.is_a?(String)
+    encoded = value.encoding == Encoding::UTF_8 ? value : value.dup.force_encoding(Encoding::UTF_8)
+    encoded.valid_encoding?
+  rescue Encoding::CompatibilityError
+    false
+  end
+
   def validate_symlink_target!(entry_path, target)
-    fail_inventory("symlink target for #{entry_path} must be valid UTF-8") unless
-      target.is_a?(String) && target.encoding == Encoding::UTF_8 && target.valid_encoding?
+    fail_inventory("symlink target for #{entry_path} must be valid UTF-8") unless utf8_representable?(target)
     fail_inventory("symlink target for #{entry_path} contains a control character") if target.match?(/[\x00-\x1f\x7f]/)
     fail_inventory("symlink target for #{entry_path} must be relative") if target.empty? || target.start_with?("/")
     fail_inventory("symlink target for #{entry_path} exceeds #{MAX_PATH_BYTES} bytes") if target.bytesize > MAX_PATH_BYTES

--- a/scripts/verify-release-artifact.sh
+++ b/scripts/verify-release-artifact.sh
@@ -424,9 +424,9 @@ if [[ ! -f "${CASK_PATH}" ]]; then
   exit 66
 fi
 
-CASK_VERSION="$(ruby -ne 'puts $1 if /^\s*version "([^"]+)"/' "${CASK_PATH}")"
-CASK_SHA="$(ruby -ne 'puts $1 if /^\s*sha256 "([^"]+)"/' "${CASK_PATH}")"
-CASK_URL_TEMPLATE="$(ruby -ne 'puts $1 if /^\s*url "([^"]+)"/' "${CASK_PATH}")"
+CASK_VERSION="$(ruby -E UTF-8 -ne 'puts $1 if /^\s*version "([^"]+)"/' "${CASK_PATH}")"
+CASK_SHA="$(ruby -E UTF-8 -ne 'puts $1 if /^\s*sha256 "([^"]+)"/' "${CASK_PATH}")"
+CASK_URL_TEMPLATE="$(ruby -E UTF-8 -ne 'puts $1 if /^\s*url "([^"]+)"/' "${CASK_PATH}")"
 
 if [[ -z "${CASK_VERSION}" || -z "${CASK_SHA}" || -z "${CASK_URL_TEMPLATE}" ]]; then
   fail_check "cask-metadata" "could not read version, sha256, or url from ${CASK_PATH}"
@@ -642,7 +642,7 @@ fi
 support_contract_rows="${TMP_DIR}/expected-support-contract.tsv"
 if ! ruby -e '
   path = ARGV.fetch(0)
-  rows = File.readlines(path).each_with_object([]) do |line, found|
+  rows = File.readlines(path, encoding: Encoding::UTF_8).each_with_object([]) do |line, found|
     match = line.match(/^\s*install\s+-m\s+755\s+scripts\/([A-Za-z0-9._-]+)\s+"\$\(CONTENTS\)\/Resources\/([A-Za-z0-9._-]+)"\s*$/)
     found << [match[1], match[2]] if match
   end
@@ -667,7 +667,7 @@ while IFS=$'\t' read -r support_source support_destination; do
 done < "${support_contract_rows}"
 
 if ! ruby -e '
-  text = File.read(ARGV.fetch(0))
+  text = File.read(ARGV.fetch(0), encoding: Encoding::UTF_8)
   abort("Makefile does not bundle the viftyctl wrapper script inventory") unless text.match?(/^\s*install\s+-m\s+755\s+examples\/viftyctl\/\*\.sh\s+"\$\(WRAPPERS\)\/"\s*$/)
   abort("Makefile does not bundle the viftyctl wrapper README") unless text.match?(/^\s*install\s+-m\s+644\s+examples\/viftyctl\/README\.md\s+"\$\(WRAPPERS\)\/README\.md"\s*$/)
 ' "${BUNDLE_CONTRACT_MAKEFILE}" 2>/dev/null; then
@@ -677,7 +677,7 @@ fi
 EXPECTED_WRAPPER_SCRIPT_INVENTORY_PATH="${TMP_DIR}/expected-wrapper-scripts.txt"
 if [[ "${CURRENT_RELEASE_MANIFEST_ENTRY_KIND}" != "candidate" ]]; then
   if ! git -C "${SOURCE_REPOSITORY_ROOT}" ls-tree -r --name-only "${CURRENT_RELEASE_SOURCE_COMMIT}" -- examples/viftyctl 2>/dev/null \
-      | ruby -ne 'path = $_.strip; puts File.basename(path) if path.match?(%r{\Aexamples/viftyctl/[^/]+\.sh\z})' \
+      | ruby -E UTF-8 -ne 'path = $_.strip; puts File.basename(path) if path.match?(%r{\Aexamples/viftyctl/[^/]+\.sh\z})' \
       | LC_ALL=C sort > "${EXPECTED_WRAPPER_SCRIPT_INVENTORY_PATH}"; then
     fail_check "release-source-contract" "could not enumerate workload wrappers from ${BUNDLE_CONTRACT_DESCRIPTION}"
   fi


### PR DESCRIPTION
Discovered while installing the published v1.4.4 archive through `scripts/install-vifty.sh --public-release-archive` (the first end-to-end run of the bridge with a real published archive).

- `release-candidate-inventory.rb`: under the installer's `LANG=C` hostile environment, Ruby reports filesystem names as ASCII-8BIT, so the strict `encoding == UTF_8` check rejected every extracted path. Now validates UTF-8 representability instead.
- `verify-release-artifact.sh`: cask regex reads (`ruby -ne`) crashed with `invalid byte sequence in US-ASCII` because `Casks/vifty.rb` contains non-ASCII bytes; Makefile file-reads were also made encoding-explicit; stdin `-ne` reads use `-E UTF-8`.

## Verification
- `ReleaseCandidateInventoryTests`: 41 runs, 341 assertions, 0 failures.
- The full verifier now passes under `LANG=C` against the v1.4.4 archive (Notarized Developer ID, Gatekeeper accepted).
- The installer progressed past both failures to the privileged helper-migration stage (which requires administrator authorization and failed closed with the app untouched).

## Non-claims
- No release/tag mutation. The v1.4.4 app install itself still requires the operator-approved administrator helper migration.