### PR TITLE
Accept launchctl print-disabled '=> disabled' format in helper lifecycle

### DIFF
--- a/Sources/Vifty/DaemonInstallService.swift
+++ b/Sources/Vifty/DaemonInstallService.swift
@@ -83,7 +83,7 @@ struct DaemonLifecycleScriptLoader: Sendable {
         // This digest is compiled into the signed app executable. The resource is
         // read once into an immutable Data snapshot and only that snapshot runs.
         // Update it intentionally whenever vifty-helper-lifecycle.sh changes.
-        let expectedSHA256 = "374fa2976610adb3bb426e78ab3c135210e1c139dd24ee28533a13c3f8eede20"
+        let expectedSHA256 = "d0ba8e8ed28cd3b85d1df53db5defa30334ee933a00f1d76b09736b0c21a78bd"
         let maximumSize = 256 * 1_024
         let descriptor = Darwin.open(url.path, O_RDONLY | O_CLOEXEC | O_NOFOLLOW)
         guard descriptor >= 0 else {

--- a/Tests/Ruby/HelperLifecycleReplacementFixtureTests.rb
+++ b/Tests/Ruby/HelperLifecycleReplacementFixtureTests.rb
@@ -594,7 +594,7 @@ class HelperLifecycleReplacementFixtureTests < Minitest::Test
         print) [[ ! -e "$state" ]] ;;
         print-disabled)
           if [[ -e "$disabled" ]]; then
-            printf 'disabled services = {\n  "tech.reidar.vifty.daemon" => true\n}\n'
+            printf 'disabled services = {\n  "tech.reidar.vifty.daemon" => disabled\n}\n'
           else
             printf 'disabled services = { }\n'
           fi

--- a/Tests/ViftyCoreTests/HelperLifecycleScriptTests.swift
+++ b/Tests/ViftyCoreTests/HelperLifecycleScriptTests.swift
@@ -2102,7 +2102,7 @@ private final class LifecycleFixture {
               if [[ "${VIFTY_FIXTURE_DECOY_DISABLED:-0}" == "1" ]]; then
                 printf 'disabled services = {\\n  "techXreidarYviftyZdaemon" => true\\n}\\n'
               elif [[ -e "$disabled" ]]; then
-                printf 'disabled services = {\\n  "tech.reidar.vifty.daemon" => true\\n}\\n'
+                printf 'disabled services = {\\n  "tech.reidar.vifty.daemon" => disabled\\n}\\n'
               else
                 printf 'disabled services = { }\\n'
               fi

--- a/scripts/vifty-helper-lifecycle.sh
+++ b/scripts/vifty-helper-lifecycle.sh
@@ -1366,7 +1366,7 @@ is_service_disabled() {
     | /usr/bin/ruby -e '
       label = ARGV.fetch(0)
       disabled = STDIN.each_line.any? do |line|
-        match = line.match(/\A\s*"?([A-Za-z0-9._-]+)"?\s*=>\s*true\s*,?\s*\z/)
+        match = line.match(/\A\s*"?([A-Za-z0-9._-]+)"?\s*=>\s*(?:true|disabled)\s*,?\s*\z/)
         match && match[1] == label
       end
       exit(disabled ? 0 : 1)


### PR DESCRIPTION
Found while installing the published v1.4.4 archive: the migration's `is_service_disabled` confirmation only matched `=> true`, but macOS 26 prints `"tech.reidar.vifty.daemon" => disabled`. The `launchctl disable` succeeded (the label is in the disabled list), yet the confirmation parse failed, so the privileged teardown aborted with status 76 before removing anything — fail-closed but blocking every v1.3.2 → v1.4.4 migration on this OS.

- `vifty-helper-lifecycle.sh`: confirmation regex now accepts `=> true` or `=> disabled`.
- XCTest + Ruby lifecycle fixtures now emit the modern `=> disabled` shape; the regex still accepts the legacy `=> true` form.

## Verification
- HelperLifecycleReplacementFixtureTests: 17 runs / 142 assertions, 0 failures.
- InstallerLifecycleTrustContractTests: 21 runs / 417 assertions, 0 failures.
- HelperLifecycleScriptTests: 56/56, 0 failures.

## Non-claims
- No release/tag mutation. The v1.4.4 install itself still requires the operator-approved administrator prompt at re-run.