### PR TITLE
Harden arbiter phase confirmation, XPC request bounds, and Codex default fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Make the existing `.active` journal prerequisite explicit in the idempotent re-apply branch, bound manual and Auto-restore XPC identifiers and reasons by UTF-8 bytes, cap untrusted fan collections at the ten-fan hardware domain before traversal, and keep Codex usage an explicit opt-in rather than a default custom menu-bar field.
+
 ## [1.4.5] - 2026-08-08
 
 ### Fixed
 
 - Accept the macOS 26 `launchctl print-disabled` output format (`label => disabled`) in the helper lifecycle's disable confirmation, so the published-app migration from a v1.3.2 install can complete instead of failing closed at status 76.
-- Harden remaining review findings: require an `.active` journal phase before idempotent re-apply confirmation, bound XPC manual/auto-restore request fields, remove Codex usage from the default custom menu-bar fields, make `capabilities` fail closed when the daemon returns no usable policy, and require full request equality for prepare idempotency.
+- Preserve unreadable preferences and explicit nulls in status JSON, make `capabilities` fail closed when the daemon returns no usable policy, and require full request equality for prepare idempotency.
 
 ### Scope
 

--- a/Sources/Vifty/MenuBarStatusPresentation.swift
+++ b/Sources/Vifty/MenuBarStatusPresentation.swift
@@ -51,7 +51,7 @@ enum MenuBarField: String, Codable, CaseIterable, Identifiable {
 
     var id: String { rawValue }
 
-    static let defaultCustomFields: [MenuBarField] = [.temperature, .fanStrength, .codexUsage]
+    static let defaultCustomFields: [MenuBarField] = [.temperature, .fanStrength]
 
     var label: String {
         switch self {

--- a/Sources/ViftyCore/ViftyDaemonProtocol.swift
+++ b/Sources/ViftyCore/ViftyDaemonProtocol.swift
@@ -45,6 +45,11 @@ public enum ViftyDaemonConstants {
 }
 
 public enum XPCFanControlCoding {
+    private static let maximumFanCount = 10
+    private static let maximumTransactionIDUTF8Bytes = 256
+    private static let maximumSessionIDUTF8Bytes = 256
+    private static let maximumReasonUTF8Bytes = 512
+
     public static func encode(_ request: ManualFanControlRequest) -> NSDictionary {
         [
             "transactionID": request.transactionID,
@@ -58,9 +63,16 @@ public enum XPCFanControlCoding {
     public static func decodeManualRequest(_ dictionary: NSDictionary) -> ManualFanControlRequest? {
         guard let transactionID = dictionary["transactionID"] as? String,
               let sessionID = dictionary["sessionID"] as? String,
-              let expectedFanIDs = intArray(dictionary["expectedFanIDs"]),
-              let targetRPMByFanID = decodeTargets(dictionary["targetRPMByFanID"]),
+              let expectedFanIDs = intArray(dictionary["expectedFanIDs"], maximumCount: maximumFanCount),
+              let targetRPMByFanID = decodeTargets(dictionary["targetRPMByFanID"], maximumCount: maximumFanCount),
               let reason = dictionary["reason"] as? String else {
+            return nil
+        }
+        guard transactionID.utf8.count <= maximumTransactionIDUTF8Bytes,
+              sessionID.utf8.count <= maximumSessionIDUTF8Bytes,
+              reason.utf8.count <= maximumReasonUTF8Bytes,
+              expectedFanIDs.count <= maximumFanCount,
+              targetRPMByFanID.count <= maximumFanCount else {
             return nil
         }
         return ManualFanControlRequest(
@@ -87,9 +99,14 @@ public enum XPCFanControlCoding {
 
     public static func decodeAutoRestoreRequest(_ dictionary: NSDictionary) -> AutoRestoreRequest? {
         guard let transactionID = dictionary["transactionID"] as? String,
-              let expectedFanIDs = intArray(dictionary["expectedFanIDs"]),
+              let expectedFanIDs = intArray(dictionary["expectedFanIDs"], maximumCount: maximumFanCount),
               let reason = dictionary["reason"] as? String,
               let allowRestoreAllTrustedFans = bool(dictionary["allowRestoreAllTrustedFans"]) else {
+            return nil
+        }
+        guard transactionID.utf8.count <= maximumTransactionIDUTF8Bytes,
+              reason.utf8.count <= maximumReasonUTF8Bytes,
+              expectedFanIDs.count <= maximumFanCount else {
             return nil
         }
         return AutoRestoreRequest(
@@ -228,8 +245,9 @@ public enum XPCFanControlCoding {
         NSDictionary(dictionary: Dictionary(uniqueKeysWithValues: targets.map { (String($0.key), $0.value) }))
     }
 
-    private static func decodeTargets(_ value: Any?) -> [Int: Int]? {
+    private static func decodeTargets(_ value: Any?, maximumCount: Int? = nil) -> [Int: Int]? {
         guard let dictionary = value as? NSDictionary else { return nil }
+        if let maximumCount, dictionary.count > maximumCount { return nil }
         var targets: [Int: Int] = [:]
         for (key, value) in dictionary {
             guard let key = key as? String,
@@ -241,8 +259,9 @@ public enum XPCFanControlCoding {
         return targets
     }
 
-    private static func intArray(_ value: Any?) -> [Int]? {
-        guard let values = value as? [Any] else { return nil }
+    private static func intArray(_ value: Any?, maximumCount: Int? = nil) -> [Int]? {
+        guard let values = value as? NSArray else { return nil }
+        if let maximumCount, values.count > maximumCount { return nil }
         var result: [Int] = []
         for value in values {
             guard let decoded = int(value) else { return nil }

--- a/Sources/ViftyFanControlSafety/FanControlArbiter.swift
+++ b/Sources/ViftyFanControlSafety/FanControlArbiter.swift
@@ -323,6 +323,7 @@ public actor FanControlArbiter {
         }
 
         if let existing,
+           existing.phase == .active,
            existing.expectedFanIDs == reservedFanIDs,
            existing.targetRPMByFanID == mergedTargets,
            (try? confirmApplied(

--- a/Tests/ViftyCoreTests/AppModelMenuBarTests.swift
+++ b/Tests/ViftyCoreTests/AppModelMenuBarTests.swift
@@ -405,6 +405,7 @@ final class AppModelMenuBarTests: XCTestCase {
             agentStatusReader: { nil }
         )
         model.selectedSensorID = "Tp09"
+        model.setMenuBarCustomField(.codexUsage, enabled: true)
         model.menuBarDisplayMode = .custom
 
         await model.pollOnce()
@@ -621,6 +622,7 @@ final class AppModelMenuBarTests: XCTestCase {
             agentStatusReader: { nil }
         )
 
+        model.setMenuBarCustomField(.codexUsage, enabled: true)
         model.menuBarDisplayMode = .custom
         await model.pollOnce()
 
@@ -798,7 +800,7 @@ final class AppModelMenuBarTests: XCTestCase {
             (.averageFanRPM, "-- RPM avg"),
             (.adapterWattage, "-- W"),
             (.codexUsage, "Ai --"),
-            (.custom, "-- C | --% fan | Ai --"),
+            (.custom, "-- C | --% fan"),
             (.temperatureAndRPM, "-- C | -- RPM"),
             (.ownerTemperatureAndRPM, "Owner? | -- C | -- RPM")
         ]
@@ -812,7 +814,7 @@ final class AppModelMenuBarTests: XCTestCase {
     }
 
     func testExtractedMenuBarPresentationTypesPreserveDefaults() {
-        XCTAssertEqual(MenuBarField.defaultCustomFields, [.temperature, .fanStrength, .codexUsage])
+        XCTAssertEqual(MenuBarField.defaultCustomFields, [.temperature, .fanStrength])
         XCTAssertEqual(MenuBarStatusItemPresentation.placeholder.tooltip, "Vifty")
         XCTAssertTrue(MenuBarStatusItemPresentation.placeholder.needsTelemetryPrime)
     }

--- a/Tests/ViftyCoreTests/AppModelPreferencesTests.swift
+++ b/Tests/ViftyCoreTests/AppModelPreferencesTests.swift
@@ -350,7 +350,7 @@ final class AppModelPreferencesTests: XCTestCase {
         let store = AppPreferencesStore(url: preferencesURL, legacyDefaults: nil)
         let model = AppModel(preferencesStore: store)
 
-        XCTAssertEqual(model.menuBarCustomFields, [.temperature, .fanStrength, .codexUsage])
+        XCTAssertEqual(model.menuBarCustomFields, [.temperature, .fanStrength])
 
         model.menuBarDisplayMode = .custom
         model.menuBarCustomFields = [.codexUsage, .fanStrength, .owner, .temperature, .codexUsage]
@@ -554,7 +554,7 @@ final class AppModelPreferencesTests: XCTestCase {
         let loaded = store.load()
 
         XCTAssertEqual(loaded.menuBarDisplayMode, .temperature)
-        XCTAssertEqual(loaded.menuBarCustomFields, [.temperature, .fanStrength, .codexUsage])
+        XCTAssertEqual(loaded.menuBarCustomFields, [.temperature, .fanStrength])
         XCTAssertEqual(loaded.startupMode, .auto)
         XCTAssertEqual(loaded.textScale, .standard)
         XCTAssertTrue(loaded.notificationSettings.helperFailure)

--- a/Tests/ViftyCoreTests/FanControlArbiterTests.swift
+++ b/Tests/ViftyCoreTests/FanControlArbiterTests.swift
@@ -624,6 +624,34 @@ final class FanControlArbiterTests: XCTestCase {
         }
     }
 
+    func testMatchingNonActiveJournalCannotUseIdempotentConfirmation() async throws {
+        let hardware = FakePrivilegedFanControlHardware(fans: [
+            Self.fan(id: 0, mode: .forced, targetRPM: 3_200),
+            Self.fan(id: 1, mode: .forced, targetRPM: 3_300)
+        ])
+        try await withArbiter(hardware: hardware) { arbiter, store in
+            try store.save(FanControlJournalRecord(
+                transactionID: "manual-1",
+                owner: .manual(sessionID: "session-1"),
+                phase: .applying,
+                expectedFanIDs: [0, 1],
+                targetRPMByFanID: [0: 3_200, 1: 3_300],
+                appliedFanIDs: [0, 1],
+                createdAt: Date(timeIntervalSince1970: 1),
+                updatedAt: Date(timeIntervalSince1970: 2)
+            ))
+
+            do {
+                _ = try await arbiter.applyManual(Self.manualRequest())
+                XCTFail("Expected unresolved non-active journal refusal")
+            } catch {
+                XCTAssertTrue(error.localizedDescription.contains("owned by unresolved transaction"))
+            }
+            XCTAssertTrue(hardware.appliedFanIDs.isEmpty)
+            XCTAssertEqual(try store.load()?.phase, .applying)
+        }
+    }
+
     func testSameManualSessionCanApplyLaterPartialBatchWithoutShrinkingExpectedDomain() async throws {
         let hardware = FakePrivilegedFanControlHardware(fans: Self.twoAutomaticFans)
         try await withArbiter(hardware: hardware) { arbiter, store in

--- a/Tests/ViftyCoreTests/XPCFanControlCodingTests.swift
+++ b/Tests/ViftyCoreTests/XPCFanControlCodingTests.swift
@@ -114,4 +114,99 @@ final class XPCFanControlCodingTests: XCTestCase {
 
         XCTAssertNil(XPCFanControlCoding.decodeManualRequest(malformed))
     }
+
+    func testManualRequestBoundsIdentifiersAndReasonByUTF8Bytes() {
+        let base: [String: Any] = [
+            "transactionID": "manual-1",
+            "sessionID": "session-1",
+            "expectedFanIDs": [0],
+            "targetRPMByFanID": ["0": 3_000],
+            "reason": "Fixed"
+        ]
+
+        var oversizedTransaction = base
+        oversizedTransaction["transactionID"] = String(repeating: "é", count: 129)
+        XCTAssertNil(XPCFanControlCoding.decodeManualRequest(oversizedTransaction as NSDictionary))
+
+        var oversizedSession = base
+        oversizedSession["sessionID"] = String(repeating: "é", count: 129)
+        XCTAssertNil(XPCFanControlCoding.decodeManualRequest(oversizedSession as NSDictionary))
+
+        var oversizedReason = base
+        oversizedReason["reason"] = String(repeating: "é", count: 257)
+        XCTAssertNil(XPCFanControlCoding.decodeManualRequest(oversizedReason as NSDictionary))
+
+        var bounded = base
+        bounded["transactionID"] = String(repeating: "é", count: 128)
+        bounded["sessionID"] = String(repeating: "é", count: 128)
+        bounded["reason"] = String(repeating: "é", count: 256)
+        XCTAssertNotNil(XPCFanControlCoding.decodeManualRequest(bounded as NSDictionary))
+    }
+
+    func testManualRequestRejectsOversizedFanCollections() {
+        let oversizedFanIDs = Array(0...10)
+        let oversizedTargets = Dictionary(
+            uniqueKeysWithValues: oversizedFanIDs.map { (String($0), 3_000) }
+        )
+
+        XCTAssertNil(
+            XPCFanControlCoding.decodeManualRequest([
+                "transactionID": "manual-1",
+                "sessionID": "session-1",
+                "expectedFanIDs": oversizedFanIDs,
+                "targetRPMByFanID": ["0": 3_000],
+                "reason": "Fixed"
+            ] as NSDictionary)
+        )
+
+        let boundedFanIDs = Array(0..<10)
+        let boundedTargets = Dictionary(
+            uniqueKeysWithValues: boundedFanIDs.map { (String($0), 3_000) }
+        )
+        XCTAssertNotNil(
+            XPCFanControlCoding.decodeManualRequest([
+                "transactionID": "manual-1",
+                "sessionID": "session-1",
+                "expectedFanIDs": boundedFanIDs,
+                "targetRPMByFanID": boundedTargets,
+                "reason": "Fixed"
+            ] as NSDictionary)
+        )
+        XCTAssertNil(
+            XPCFanControlCoding.decodeManualRequest([
+                "transactionID": "manual-1",
+                "sessionID": "session-1",
+                "expectedFanIDs": [0],
+                "targetRPMByFanID": oversizedTargets,
+                "reason": "Fixed"
+            ] as NSDictionary)
+        )
+    }
+
+    func testAutoRestoreRequestBoundsUTF8BytesAndFanCardinality() {
+        let base: [String: Any] = [
+            "transactionID": "restore-1",
+            "expectedFanIDs": [0],
+            "reason": "Restore",
+            "allowRestoreAllTrustedFans": false
+        ]
+
+        var oversizedTransaction = base
+        oversizedTransaction["transactionID"] = String(repeating: "é", count: 129)
+        XCTAssertNil(XPCFanControlCoding.decodeAutoRestoreRequest(oversizedTransaction as NSDictionary))
+
+        var oversizedReason = base
+        oversizedReason["reason"] = String(repeating: "é", count: 257)
+        XCTAssertNil(XPCFanControlCoding.decodeAutoRestoreRequest(oversizedReason as NSDictionary))
+
+        var oversizedFanIDs = base
+        oversizedFanIDs["expectedFanIDs"] = Array(0...10)
+        XCTAssertNil(XPCFanControlCoding.decodeAutoRestoreRequest(oversizedFanIDs as NSDictionary))
+
+        var bounded = base
+        bounded["transactionID"] = String(repeating: "é", count: 128)
+        bounded["reason"] = String(repeating: "é", count: 256)
+        bounded["expectedFanIDs"] = Array(0..<10)
+        XCTAssertNotNil(XPCFanControlCoding.decodeAutoRestoreRequest(bounded as NSDictionary))
+    }
 }


### PR DESCRIPTION
Repairs and rebases the retained hardening work on current `main`.

## What changed

- Bound XPC transaction IDs, session IDs, and reasons by UTF-8 byte length.
- Preflight raw XPC fan collections before traversal and cap them at the physical ten-fan domain.
- Make Codex usage an opt-in menu-bar field for new/default preferences while preserving explicitly saved Codex selections.
- Keep the arbiter's `.active` phase requirement explicit as defense in depth and cover the non-active journal regression.
- Correct the changelog: these changes were not part of v1.4.5 and now appear under Unreleased.

## Validation

- XPC targeted tests: 10/10 passed.
- Arbiter targeted tests: 35/35 passed.
- Preferences targeted tests: 24/24 passed.
- Directly affected menu-bar tests passed.
- A standalone checkout at exact head passed the full local `make verify-full` gate.

The full gate includes the fast suite, warnings-as-errors build, release-app assembly and metadata checks, and the repository's slow validation suites.

## Boundaries

- This is not a signed release, tag, notarization, or hardware/manual acceptance claim.
- The arbiter phase check is intentionally described as defense in depth because an earlier guard already rejects a non-active journal.
