### PR TITLE
Fail closed when capabilities policy is unusable and require full idempotency equality

### DIFF
--- a/Sources/ViftyCore/AgentControlService.swift
+++ b/Sources/ViftyCore/AgentControlService.swift
@@ -200,9 +200,20 @@ public actor AgentControlService {
         }
 
         if let lease = activeLease,
-           lease.request.idempotencyKey == request.idempotencyKey,
-           lease.isActive(at: decisionClock()) {
-            return status()
+           lease.request.idempotencyKey == request.idempotencyKey {
+            guard lease.request == request else {
+                let decision = AgentControlDecision.denied(
+                    .invalidArguments,
+                    message: "Idempotency key is already in use by a different cooling request."
+                )
+                lastDecision = decision
+                lastErrorCode = decision.errorCode
+                appendAudit(action: "prepare-denied", leaseID: lease.id, message: decision.message)
+                return status()
+            }
+            if lease.isActive(at: decisionClock()) {
+                return status()
+            }
         }
 
         if let lease = activeLease,

--- a/Sources/ViftyCore/ViftyCtlRunner.swift
+++ b/Sources/ViftyCore/ViftyCtlRunner.swift
@@ -1372,19 +1372,25 @@ public struct ViftyCtlRunner: Sendable {
                 return ViftyCtlResult(stdout: stdout)
             case .capabilities(let json):
                 let capabilities = await capabilitiesReport()
+                let policyUsable = capabilities.daemonStatusAvailable && capabilities.policyStatusAvailable
                 if json {
                     return ViftyCtlResult(
                         stdout: try encodeJSON(capabilities) + "\n",
-                        exitCode: capabilities.daemonStatusAvailable ? 0 : capabilities.exitCodes.unavailable
+                        exitCode: policyUsable ? 0 : capabilities.exitCodes.unavailable
                     )
                 }
-                let stderr = capabilities.agentControlStatusError.map {
-                    "viftyctl capabilities: daemon status unavailable; policy is a disabled fallback: \($0)\n"
-                } ?? ""
+                let stderr: String
+                if let error = capabilities.agentControlStatusError {
+                    stderr = "viftyctl capabilities: daemon status unavailable; policy is a disabled fallback: \(error)\n"
+                } else if !capabilities.policyStatusAvailable {
+                    stderr = "viftyctl capabilities: daemon returned no usable policy; policy is a disabled fallback\n"
+                } else {
+                    stderr = ""
+                }
                 return ViftyCtlResult(
                     stdout: capabilities.commands.joined(separator: "\n") + "\n",
                     stderr: stderr,
-                    exitCode: capabilities.daemonStatusAvailable ? 0 : capabilities.exitCodes.unavailable
+                    exitCode: policyUsable ? 0 : capabilities.exitCodes.unavailable
                 )
             case .agentRule(let json):
                 if json {
@@ -1721,7 +1727,7 @@ public struct ViftyCtlRunner: Sendable {
     private func capabilitiesReport() async -> ViftyCtlCapabilities {
         do {
             let status = try await client.status()
-            let policy = status.policy ?? AgentControlPolicy(enabled: status.enabled).snapshot
+            let policy = status.policy ?? AgentControlPolicy(enabled: false).snapshot
             return ViftyCtlCapabilities(
                 policy: policy,
                 policyStatusAvailable: status.policy != nil

--- a/Tests/ViftyCoreTests/ViftyCtlRunnerTests.swift
+++ b/Tests/ViftyCoreTests/ViftyCtlRunnerTests.swift
@@ -382,7 +382,9 @@ final class ViftyCtlRunnerTests: XCTestCase {
 
         let result = try await runner.run(.capabilities(json: true))
 
-        XCTAssertEqual(result.exitCode, 0)
+        // The policy is unusable, so exit-code automation must fail closed even
+        // though the daemon itself responded.
+        XCTAssertEqual(result.exitCode, 69)
         let data = try XCTUnwrap(result.stdout.data(using: .utf8))
         let json = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
         XCTAssertEqual(json["daemonStatusAvailable"] as? Bool, true)
@@ -390,7 +392,7 @@ final class ViftyCtlRunnerTests: XCTestCase {
         XCTAssertEqual(json["policySource"] as? String, ViftyCtlPolicySource.daemonStatus.rawValue)
         XCTAssertNil(json["agentControlStatusError"] as? String)
         let policy = try XCTUnwrap(json["policy"] as? [String: Any])
-        XCTAssertEqual(policy["enabled"] as? Bool, true)
+        XCTAssertEqual(policy["enabled"] as? Bool, false)
         XCTAssertEqual(policy["maxDurationSeconds"] as? Int, 1_800)
     }
 


### PR DESCRIPTION
Split from the closed batch-2 PR to isolate a CI suite-exit flake:

- **AGENT-05**: `capabilities` exits `exitCodes.unavailable` when the daemon responds without a usable policy; the fallback policy is explicitly disabled.
- **AGENT-08**: prepare idempotency requires full request equality; a reused key with different parameters is denied and audited.

## Verification
- ViftyCtlRunnerTests + AgentControlServiceTests: 130 tests, 0 failures (capabilities test updated to the new exit contract).

Note: commit is unsigned (1Password locked); will not affect CI.