### PR TITLE
Fix SwiftPM product path discovery across toolchains

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,10 @@ RELEASE_SWIFT_PLATFORM_DIR ?= $(RELEASE_ARCHITECTURE)-apple-macosx
 SWIFT_TRIPLE_ARGS = $(if $(filter release,$(CONFIGURATION)),--triple "$(RELEASE_SWIFT_TRIPLE)",)
 SWIFT_PROVENANCE_ARGS = $(if $(SWIFT_BUILD_PROVENANCE_FILE),-Xlinker -sectcreate -Xlinker __TEXT -Xlinker __vifty_src -Xlinker "$(SWIFT_BUILD_PROVENANCE_FILE)",)
 SWIFT_BUILD_ARGS = $(if $(SWIFT_BUILD_PATH),--build-path "$(SWIFT_BUILD_PATH)",) $(SWIFT_TRIPLE_ARGS) $(SWIFT_PROVENANCE_ARGS) $(SWIFT_BUILD_EXTRA_ARGS)
-SWIFT_PRODUCTS_DIR = $(if $(filter release,$(CONFIGURATION)),$(if $(SWIFT_BUILD_PATH),$(SWIFT_BUILD_PATH)/$(RELEASE_SWIFT_PLATFORM_DIR)/$(CONFIGURATION),.build/$(RELEASE_SWIFT_PLATFORM_DIR)/$(CONFIGURATION)),$(if $(SWIFT_BUILD_PATH),$(SWIFT_BUILD_PATH)/$(CONFIGURATION),.build/$(CONFIGURATION)))
+# SwiftPM's product layout is toolchain-dependent (for example, Xcode 26
+# places release products under .build/out/Products/Release). Ask SwiftPM for
+# the path it actually selected, while preserving explicit caller overrides.
+SWIFT_PRODUCTS_DIR ?= $(shell swift build $(SWIFT_BUILD_ARGS) -c $(CONFIGURATION) --show-bin-path)
 VERIFY_TEST_TARGET ?= test-fast
 SLOW_TEST_SKIP_ARGS := --skip 'ViftyCoreTests\.(AgentCoolingEvidenceScriptTests|AgentRunSmokeEvidenceScriptTests|GuardedRunScriptTests|HelperLifecycleScriptTests|InstallReplacementPreflightScriptTests|ReleaseArtifactScriptTests|ReleaseManifestScriptTests|ReleaseMetadataScriptTests|UIReviewEvidenceScriptTests|ValidationEvidenceReviewScriptTests|ValidationEvidenceScriptTests|ValidationReportSummaryScriptTests)'
 RELEASE_VERSION ?= $(shell /usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' Resources/Info.plist)

--- a/Tests/ViftyCoreTests/MakefileTrustGateTests.swift
+++ b/Tests/ViftyCoreTests/MakefileTrustGateTests.swift
@@ -78,7 +78,7 @@ final class MakefileTrustGateTests: XCTestCase {
         XCTAssertTrue(makefile.contains("SWIFT_BUILD_PROVENANCE_FILE ?="))
         XCTAssertTrue(makefile.contains("SWIFT_PROVENANCE_ARGS = $(if $(SWIFT_BUILD_PROVENANCE_FILE),-Xlinker -sectcreate -Xlinker __TEXT -Xlinker __vifty_src"))
         XCTAssertTrue(makefile.contains("SWIFT_BUILD_ARGS = $(if $(SWIFT_BUILD_PATH),--build-path \"$(SWIFT_BUILD_PATH)\",) $(SWIFT_TRIPLE_ARGS) $(SWIFT_PROVENANCE_ARGS)"))
-        XCTAssertTrue(makefile.contains("SWIFT_PRODUCTS_DIR = $(if $(filter release,$(CONFIGURATION))"))
+        XCTAssertTrue(makefile.contains("SWIFT_PRODUCTS_DIR ?= $(shell swift build $(SWIFT_BUILD_ARGS) -c $(CONFIGURATION) --show-bin-path)"))
         XCTAssertTrue(makefile.contains("APP_DIR ?= .build/$(APP_NAME).app"))
         XCTAssertTrue(makefile.contains("ui-review-build-products: ## Build one clean-tree provenance-bound UI review product transaction"))
         XCTAssertTrue(makefile.contains("./scripts/build-ui-review-products.sh"))


### PR DESCRIPTION
## Summary

- Replace the hard-coded SwiftPM product directory with SwiftPM's selected `--show-bin-path`, while retaining an explicit `SWIFT_PRODUCTS_DIR` override.
- Update the Makefile trust regression to cover the toolchain-independent lookup.

## Validation (from the execution ledger)

- Focused Makefile trust tests: 4 passed, 0 failed.
- Full `make verify` recipe completed through source tests, warnings-as-errors build, release app assembly, plist/codesign checks, and exact product identifiers; the log recorded 1,344 tests with 0 failures and app assembly from `.build/out/Products/Release` without an override.
- Clean-tree post-commit `make app CONFIGURATION=release SIGNING_IDENTITY=-`: exit 0.

## Scope and blockers

- Source ref: `codex/cleanup-vifty-swift-products-dir-2026-08-23` at `9e411b4a00d12dc691fd05471442b552954d66dc`.
- This is a local candidate commit, not a release: no privileged administrator environment readback, signed/notarized public artifact, hardware/manual acceptance, merge, or deploy was performed.
- Administrator governance check remains blocked by the committed `gh` toolchain SHA policy.
- GitHub Actions CI is expected to run for this draft PR; no CI result is being claimed before it reports.